### PR TITLE
Checkout latest tagged commit in publish_docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get install graphviz
       - name: Checkout latest tagged commit
         run:
-          git checkout $(git tag -l | tail -1)
+          git checkout $(git describe --tags --abbrev=0)
       - name: Build docs
         run: |
           tox -e docs


### PR DESCRIPTION
In order to have clean release number in documentation, the docs should be built on a tagged commit.
Add checkout step in `publish_docs` job to checkout the latest tagged commit before building docs.