### PR TITLE
Comp 369 fix example in user guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,7 +16,8 @@ and install it in editable mode with all the extras:
    $ pip install -e ".[dev,docs,testing]"
 
 
-Build and view the docs:
+To be able to build the docs `graphviz <https://graphviz.org/>`_ has to be installed. 
+Then to build and view the docs run:
 
 .. code-block:: bash
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -47,7 +47,7 @@ Let's consider the following quantum circuit which prepares and measures a Bell 
     qc.cx(0, 1)
     qc.measure([0, 1], [0, 1])
 
-    qc.draw()
+    print(qc.draw(output='text'))
 
 ::
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -67,7 +67,7 @@ First, we need to decompose it into IQM's native gate family:
 
     qc_decomposed = transpile(qc, basis_gates=['r', 'cz'])
 
-    qc_decomposed.draw()
+    print(qc_decomposed.draw(output='text'))
 
 ::
 


### PR DESCRIPTION
- fix instructions in user-guide to visualize example circuit
- add note on requirements for building docs