### PR TITLE
COMP-323 allow barrier operations in qiskit-on-iqm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 2.1
+===========
+
+* Allow serialization of ``barrier`` operations. `#12 <https://github.com/iqm-finland/qiskit-on-iqm/pull/12>`_
+
 Version 2.0
 ===========
 

--- a/src/qiskit_iqm/qiskit_to_iqm.py
+++ b/src/qiskit_iqm/qiskit_to_iqm.py
@@ -146,6 +146,8 @@ def serialize_circuit(circuit: QiskitQuantumCircuit) -> Circuit:
             )
         elif instruction.name == 'cz':
             instructions.append(Instruction(name='cz', qubits=qubit_names, args={}))
+        elif instruction.name == 'barrier':
+            instructions.append(Instruction(name='barrier', qubits=qubit_names, args={}))
         elif instruction.name == 'measure':
             mk = MeasurementKey.from_clbit(clbits[0], circuit)
             instructions.append(Instruction(name='measurement', qubits=qubit_names, args={'key': str(mk)}))

--- a/tests/test_qiskit_to_iqm.py
+++ b/tests/test_qiskit_to_iqm.py
@@ -153,3 +153,12 @@ def test_serialize_circuit_batch_measurement(circuit):
         assert instruction.name == 'measurement'
         assert instruction.qubits == [f'qubit_{i}']
         assert instruction.args == {'key': f'c_3_0_{i}'}
+
+def test_serialize_circuit_barrier(circuit: QuantumCircuit):
+    circuit.r(theta= np.pi, phi=0, qubit=0)
+    circuit.barrier([0,1])
+    circuit_ser = serialize_circuit(circuit)
+    assert len(circuit_ser.instructions) == 2
+    assert circuit_ser.instructions[1].name == 'barrier'
+    assert circuit_ser.instructions[1].qubits == ['qubit_0', 'qubit_1']
+    assert circuit_ser.instructions[1].args == {}


### PR DESCRIPTION
Allow Qiskit on IQM to serialize barrier operations.