### PR TITLE
Use get_run_status instead of get_run to retrieve status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 2.2
+===========
+
+* Use IQM Client's ``get_run_status`` instead of ``get_run`` to retrieve status. `#13 <https://github.com/iqm-finland/qiskit-on-iqm/pull/13>`_
+* Requires iqm-client 3.2
+
 Version 2.1
 ===========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 install_requires =
     numpy
     qiskit ~= 0.34.1
-    iqm-client >= 2.0, < 3.0
+    iqm-client >= 3.2
 
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/qiskit_iqm/iqm_job.py
+++ b/src/qiskit_iqm/iqm_job.py
@@ -100,8 +100,7 @@ class IQMJob(JobV1):
         if self._result:
             return JobStatus.DONE
 
-        result = self._client.get_run(uuid.UUID(self._job_id))
+        result = self._client.get_run_status(uuid.UUID(self._job_id))
         if result.status == RunStatus.READY:
-            self._result = self._format_iqm_result(result)
             return JobStatus.DONE
         return JobStatus.RUNNING

--- a/src/qiskit_iqm/iqm_job.py
+++ b/src/qiskit_iqm/iqm_job.py
@@ -103,4 +103,6 @@ class IQMJob(JobV1):
         result = self._client.get_run_status(uuid.UUID(self._job_id))
         if result.status == RunStatus.READY:
             return JobStatus.DONE
+        if result.status == RunStatus.FAILED:
+            return JobStatus.ERROR
         return JobStatus.RUNNING

--- a/tests/test_iqm_job.py
+++ b/tests/test_iqm_job.py
@@ -70,24 +70,20 @@ def test_status_for_ready_result(job):
     assert result.get_memory() == ['11', '10', '10']
 
 
-def test_status_done(job, iqm_result_single_register):
-    client_result = RunResult(status=RunStatus.READY, measurements=iqm_result_single_register)
-    when(job._client).get_run(uuid.UUID(job.job_id())).thenReturn(client_result)
+def test_status_done(job):
+    client_result = RunResult(status=RunStatus.READY, measurements=None)
+    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenReturn(client_result)
     assert job.status() == JobStatus.DONE
-    assert job._result is not None
-
-    # Assert that repeated call does not query the client (i.e. works without calling the mocked get_run)
-    assert job.status() == JobStatus.DONE
-    mockito.verify(job._client, times=1).get_run(uuid.UUID(job.job_id()))
+    assert job._result is None
 
 
 def test_status_running(job):
-    when(job._client).get_run(uuid.UUID(job.job_id())).thenReturn(RunResult(status=RunStatus.PENDING))
+    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenReturn(RunResult(status=RunStatus.PENDING))
     assert job.status() == JobStatus.RUNNING
 
 
 def test_status_fail(job):
-    when(job._client).get_run(uuid.UUID(job.job_id())).thenRaise(CircuitExecutionError)
+    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenRaise(CircuitExecutionError)
     with pytest.raises(CircuitExecutionError):
         job.status()
 

--- a/tests/test_iqm_job.py
+++ b/tests/test_iqm_job.py
@@ -18,8 +18,7 @@ import uuid
 
 import mockito
 import pytest
-from iqm_client.iqm_client import (CircuitExecutionError, IQMClient, RunResult,
-                                   RunStatus)
+from iqm_client.iqm_client import IQMClient, RunResult, RunStatus
 from mockito import mock, when
 from qiskit.providers import JobStatus
 from qiskit.result import Counts
@@ -83,9 +82,8 @@ def test_status_running(job):
 
 
 def test_status_fail(job):
-    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenRaise(CircuitExecutionError)
-    with pytest.raises(CircuitExecutionError):
-        job.status()
+    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenReturn(RunResult(status=RunStatus.FAILED))
+    assert job.status() == JobStatus.ERROR
 
 
 def test_result(job, iqm_result_two_registers):


### PR DESCRIPTION
IQM Client 3.2 introduced a new function `get_run_status` which returns the status of a job, but, unlike `get_run`, returns status only, and never returns measurement results. 

Previously, qiskit-on-iqm's `IQMJob.status()` function would return the status, but if the status was ready, it would also save the measurement results in memory behind the scenes. As a result, the consequent `IQMJob.result()` function would return the results instantaneously, without calling the client. 

With the current change, `IQMJob.status()` uses the new function of IQM Client, and thus does not save results behind the scenes when user requests the status. 