### PR TITLE
Add optional calibration_set_id parameter to IQMBackend.run

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 * Ville Bergholm <ville@meetiqm.com>
 * Olli Ahonen <olli@meetiqm.com>
 * Matthias Beuerle <matthias.beuerle@meetiqm.com>
+* Rakhim Davletkaliyev <rakhim.davletkaliyev@meetiqm.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Version 4.2
 ===========
 
 * Add optional ``calibration_set_id`` parameter to ``IQMBackend.run``. `#20 <https://github.com/iqm-finland/qiskit-on-iqm/pull/20>`_
+* Update documentation regarding the use of Cortex CLI. `#20 <https://github.com/iqm-finland/qiskit-on-iqm/pull/20>`_
 
 Version 4.1
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 4.1
+===========
+
+* Add optional ``calibration_set_id`` parameter to ``IQMBackend.run``. `#20 <https://github.com/iqm-finland/qiskit-on-iqm/pull/20>`_
+
 Version 4.0
 ===========
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -128,10 +128,9 @@ If you want to use a particular calibration set, provide a ``calibration_set_id`
 
 If the IQM server you are connecting to requires authentication, you will also have to set the IQM_AUTH_SERVER,
 IQM_AUTH_USERNAME and IQM_AUTH_PASSWORD environment variables or pass them as arguments to the constructor of
-:class:`.IQMProvider`. Alternatively, you can use `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_, which
-retrieves access tokens and refreshes them periodically in the background; set the ``IQM_TOKENS_FILE`` environment
-variable to use those tokens. See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_
-for details.
+:class:`.IQMProvider`. Alternatively, authorize with `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to
+retrieve and automatically refresh access tokens, then set the ``IQM_TOKENS_FILE`` environment variable to use those
+tokens. See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_ for details.
 
 It is also possible to run multiple circuits at once, as a batch. In many scenarios this is more time efficient than
 running the circuits one by one. Currently, the batch running feature is meant to be used with parameterized circuits

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -122,16 +122,23 @@ Now that we have everything ready, we can run the circuit against the available 
     print(job.result().get_counts())
 
 Note that the code snippet above assumes that you have set the variables ``iqm_server_url`` and ``iqm_settings_path``.
+If you want to use the latest calibration set, omit ``settings`` argument from the ``backend.run`` call.
+If you want to use a particular calibration set, provide a ``calibration_set_id`` integer argument. You cannot set both
+``settings`` and ``calibration_set_id`` simultaneously, as IQM server rejects such requests.
+
 If the IQM server you are connecting to requires authentication, you will also have to set the IQM_AUTH_SERVER,
 IQM_AUTH_USERNAME and IQM_AUTH_PASSWORD environment variables or pass them as arguments to the constructor of
-:class:`.IQMProvider`.
+:class:`.IQMProvider`. Alternatively, you can use `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_, which
+retrieves access tokens and refreshes them periodically in the background; set the ``IQM_TOKENS_FILE`` environment
+variable to use those tokens. See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_
+for details.
 
 It is also possible to run multiple circuits at once, as a batch. In many scenarios this is more time efficient than
 running the circuits one by one. Currently, the batch running feature is meant to be used with parameterized circuits
 only. A parameterized circuit can be constructed and ran with various values of the parameter(s) as follows:
 
 .. code-block:: python
-        
+
         import numpy as np
         from qiskit.circuit import Parameter
 
@@ -150,9 +157,9 @@ only. A parameterized circuit can be constructed and ran with various values of 
 
         circuits = [qc_decomposed.bind_parameters({theta: n})
                         for n in theta_range]
-        
+
         qubit_mapping={qc_decomposed.qubits[0]: 'QB1', qc_decomposed.qubits[1]: 'QB2'}
-        
+
         job = backend.run(qc_decomposed, shots=1000, qubit_mapping=qubit_mapping, settings=settings)
 
         print(job.result().get_counts())

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 install_requires =
     numpy
     qiskit ~= 0.34.1
-    iqm-client >= 5.1, < 6.0
+    iqm-client >= 6.1, < 7.0
 
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 install_requires =
     numpy
     qiskit ~= 0.34.1
-    iqm-client >= 5.0, < 6.0
+    iqm-client >= 5.1, < 6.0
 
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/qiskit_iqm/iqm_backend.py
+++ b/src/qiskit_iqm/iqm_backend.py
@@ -62,6 +62,7 @@ class IQMBackend(BackendV2):
         qubit_mapping = options.get('qubit_mapping', self.options.qubit_mapping)
         shots = options.get('shots', self.options.shots)
         settings = options.get('settings', self.options.settings)
+        calibration_set_id = options.get('calibration_set_id', self.options.calibration_set_id)
 
         if qubit_mapping is not None:
             # process qubit mapping for each circuit separately
@@ -79,6 +80,7 @@ class IQMBackend(BackendV2):
         uuid = self.client.submit_circuits(circuits_serialized,
                                            qubit_mapping=qubit_mapping,
                                            settings=settings,
+                                           calibration_set_id=calibration_set_id,
                                            shots=shots)
         return IQMJob(self, str(uuid), shots=shots)
 

--- a/src/qiskit_iqm/iqm_backend.py
+++ b/src/qiskit_iqm/iqm_backend.py
@@ -40,7 +40,7 @@ class IQMBackend(BackendV2):
 
     @classmethod
     def _default_options(cls) -> Options:
-        return Options(shots=1024, qubit_mapping=None, settings=None)
+        return Options(shots=1024, qubit_mapping=None, settings=None, calibration_set_id=None)
 
     @property
     def target(self) -> Target:

--- a/tests/test_iqm_backend.py
+++ b/tests/test_iqm_backend.py
@@ -84,7 +84,7 @@ def test_run_with_non_default_settings(backend):
                                         shots=shots
                                         ).thenReturn(some_id)
 
-    backend.run([circuit], qubit_mapping=None, shots=shots, settings=settings)
+    backend.run([circuit], qubit_mapping=None, settings=settings, shots=shots)
 
 
 def test_run_with_custom_calibration_set_id(backend):
@@ -101,7 +101,7 @@ def test_run_with_custom_calibration_set_id(backend):
                                         shots=shots
                                         ).thenReturn(some_id)
 
-    backend.run([circuit], qubit_mapping=None, shots=shots, settings=None, calibration_set_id=calibration_set_id)
+    backend.run([circuit], qubit_mapping=None, settings=None, calibration_set_id=calibration_set_id, shots=shots)
 
 
 def test_run_circuit_with_qubit_mapping(backend):

--- a/tests/test_iqm_backend.py
+++ b/tests/test_iqm_backend.py
@@ -85,6 +85,22 @@ def test_run_with_non_default_settings(backend):
     backend.run([circuit], qubit_mapping=None, shots=shots, settings=settings)
 
 
+def test_run_with_custom_calibration_set_id(backend):
+    circuit = QuantumCircuit(1, 1)
+    circuit.measure(0, 0)
+    circuit_ser = serialize_circuit(circuit)
+    some_id = uuid.uuid4()
+    shots = 10
+    calibration_set_id = 24
+    when(backend.client).submit_circuits([circuit_ser],
+                                        qubit_mapping=None,
+                                        calibration_set_id=calibration_set_id,
+                                        shots=shots
+                                        ).thenReturn(some_id)
+
+    backend.run([circuit], qubit_mapping=None, shots=shots, settings=calibration_set_id)
+
+
 def test_run_circuit_with_qubit_mapping(backend):
     circuit = QuantumCircuit(1, 1)
     circuit.measure(0, 0)

--- a/tests/test_iqm_backend.py
+++ b/tests/test_iqm_backend.py
@@ -57,6 +57,7 @@ def test_run_single_circuit(backend):
     when(backend.client).submit_circuits([circuit_ser],
                                          qubit_mapping=None,
                                          settings=None,
+                                         calibration_set_id=None,
                                          shots=shots
                                          ).thenReturn(some_id)
     job = backend.run(circuit, qubit_mapping=None, shots=shots)
@@ -79,6 +80,7 @@ def test_run_with_non_default_settings(backend):
     when(backend.client).submit_circuits([circuit_ser],
                                         qubit_mapping=None,
                                         settings=settings,
+                                        calibration_set_id=None,
                                         shots=shots
                                         ).thenReturn(some_id)
 
@@ -94,11 +96,12 @@ def test_run_with_custom_calibration_set_id(backend):
     calibration_set_id = 24
     when(backend.client).submit_circuits([circuit_ser],
                                         qubit_mapping=None,
+                                        settings=None,
                                         calibration_set_id=calibration_set_id,
                                         shots=shots
                                         ).thenReturn(some_id)
 
-    backend.run([circuit], qubit_mapping=None, shots=shots, settings=calibration_set_id)
+    backend.run([circuit], qubit_mapping=None, shots=shots, settings=None, calibration_set_id=calibration_set_id)
 
 
 def test_run_circuit_with_qubit_mapping(backend):
@@ -111,6 +114,7 @@ def test_run_circuit_with_qubit_mapping(backend):
         [circuit_ser],
         qubit_mapping={'qubit_0': 'QB1'},
         settings=None,
+        calibration_set_id=None,
         shots=shots
     ).thenReturn(some_id)
 
@@ -134,6 +138,7 @@ def test_run_batch_of_circuits(backend):
         circuits_serialized,
         qubit_mapping={'qubit_0': 'QB1', 'qubit_1': 'QB2'},
         settings=None,
+        calibration_set_id=None,
         shots=shots
     ).thenReturn(some_id)
 


### PR DESCRIPTION
[IQM Client 6.1](https://github.com/iqm-finland/iqm-client/commit/45654f63d3f363f2996d143f145a38cd19785b35) now allows to specify a `calibration_set_id`. This PR updates qiskit-on-iqm accordingly.