### PR TITLE
Populate circuit_metadata from job results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration 
+name: Continuous Integration
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
-          python -m pip install tox-gh-actions
+          python -m pip install tox-gh-actions==2.12.0
       - name: Run tests
         run: tox
   test_docs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 6.3
+===========
+
+* Construct ``IQMJob.circuit_metadata`` from data retrieved from the server, if needed. `#36 <https://github.com/iqm-finland/qiskit-on-iqm/pull/36>`_
+
 Version 6.2
 ===========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 install_requires =
     numpy
     qiskit ~= 0.39.1
-    iqm-client >= 9.0, < 10.0
+    iqm-client >= 10.0, < 11.0
 
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/qiskit_iqm/iqm_backend.py
+++ b/src/qiskit_iqm/iqm_backend.py
@@ -91,7 +91,7 @@ class IQMBackend(BackendV2):
         shots = options.get('shots', self.options.shots)
         calibration_set_id = options.get('calibration_set_id', self.options.calibration_set_id)
 
-        circuits_serialized = [self.serialize_circuit(circuit) for circuit in circuits]
+        circuits_serialized: list[Circuit] = [self.serialize_circuit(circuit) for circuit in circuits]
         qubit_mapping = {str(idx): qb for idx, qb in self._idx_to_qb.items()}
         uuid = self.client.submit_circuits(
             circuits_serialized, qubit_mapping=qubit_mapping, calibration_set_id=calibration_set_id, shots=shots
@@ -164,4 +164,4 @@ class IQMBackend(BackendV2):
                     f'You need to transpile the circuit before execution.'
                 )
 
-        return Circuit(name=circuit.name, instructions=instructions)
+        return Circuit(name=circuit.name, instructions=instructions, metadata=circuit.metadata)


### PR DESCRIPTION
Qiskit circuit class contains attribute`QuantumCircuit.metadata`: an arbitrary key value metadata to associate with the circuit ([see docs](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html?highlight=quantumcircuit#qiskit.circuit.QuantumCircuit.metadata)). `IQMBackend.run()` takes that data and populates `IQMJob.circuit_metadata`; later, when results are retrieved via `IQMJob.result()`, the same data is copied into the result in. However, this only works if `IQMBackend.run()` and `IQMJob.result()` are called in the same Python session.

A new version of the IQM server returns a complete copy of the original request; [IQM Client version 10](https://github.com/iqm-finland/iqm-client/pull/65) implements related changes. 

This Qiskit-on-IQM PR takes advantage of that feature, and populates `IQMJob.circuit_metadata` (if needed) with data retrieved from the server.