### PR TITLE
Add readout errors to noise model

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -171,10 +171,10 @@ Now we can study how the circuit gets transpiled:
            meas_2: ═══════════════════════════════════════════════════════════════════════════╩═
 
 
-Simulating the execution of a transpiled circuit locally
---------------------------------------------------------
+Noisy simulation of quantum circuit execution
+---------------------------------------------
 
-The execution of circuits can be simulated locally, with a noise model to mimic the real hardware as much as possible.
+The execution of circuits can be simulated locally, with a noise model to mimic the real hardware.
 To this end, Qiskit on IQM provides the class  :class:`.IQMFakeBackend` that can be instantiated with properties of a certain QPU,
 or subclasses of it such as :class:`.IQMFakeAdonis` that represent certain quantum architectures with pre-populated properties and noise model.
 
@@ -194,6 +194,7 @@ or subclasses of it such as :class:`.IQMFakeAdonis` that represent certain quant
 
 
 Above, we use an :class:`.IQMFakeAdonis` instance to run a noisy simulation of ``circuit`` on a simulated 5-qubit Adonis chip.
+The noise model includes relaxation (:math:`T_1`) and dephasing (:math:`T_2`), gate infidelities and readout errors.
 If you want to customize the noise model instead of using the default one provided by :class:`.IQMFakeAdonis`, you can create
 a copy of the fake Adonis instance with updated error profile:
 

--- a/src/qiskit_iqm/fake_backends/fake_adonis.py
+++ b/src/qiskit_iqm/fake_backends/fake_adonis.py
@@ -37,6 +37,13 @@ def IQMFakeAdonis() -> IQMFakeBackend:
         },
         single_qubit_gate_durations={"phased_rx": 40.0},
         two_qubit_gate_durations={"cz": 80.0},
+        readout_errors={
+            "QB1": {"0": 0.013, "1": 0.028},
+            "QB2": {"0": 0.035, "1": 0.087},
+            "QB3": {"0": 0.042, "1": 0.084},
+            "QB4": {"0": 0.022, "1": 0.053},
+            "QB5": {"0": 0.065, "1": 0.110},
+        },
         id_="sample-chip",
     )
 

--- a/src/qiskit_iqm/fake_backends/iqm_fake_backend.py
+++ b/src/qiskit_iqm/fake_backends/iqm_fake_backend.py
@@ -85,7 +85,7 @@ class IQMFakeBackend(IQMBackendBase):
 
     A fake backend contains information about a specific IQM system, such as the quantum architecture (number of qubits,
     connectivity), the native gate set, and a noise model based on system parameters such as relaxation (:math:`T_1`)
-    and decoherence (:math:`T_2`) times and gate infidelities.
+    and decoherence (:math:`T_2`) times, gate infidelities and readout errors.
 
     Args:
         architecture: Description of the quantum architecture associated with the backend instance.

--- a/src/qiskit_iqm/fake_backends/iqm_fake_backend.py
+++ b/src/qiskit_iqm/fake_backends/iqm_fake_backend.py
@@ -30,6 +30,7 @@ from qiskit_aer.noise.errors import depolarizing_error, thermal_relaxation_error
 from qiskit_iqm.iqm_backend import IQM_TO_QISKIT_GATE_NAME, IQMBackendBase
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class IQMErrorProfile:
     """Collection of various properties of an IQM QPU to be used for constructing error model.
@@ -45,6 +46,10 @@ class IQMErrorProfile:
             lead to average gate fidelities that would be determined by benchmarking.
         single_qubit_gate_durations: Gate duration (in ns) for each single-qubit gate
         two_qubit_gate_durations: Gate duration (in ns) for each two-qubit gate.
+        readout_errors: Single-qubit readout errors, corresponding key is the physical qubit name. For each qubit,
+            specified are the probabilities :math:`P(1|0)` to observe the state :math:`\\ket{1}`
+            given the true state should be :math:`\\ket{0}` and :math:`P(0|1)` to observe the state :math:`\\ket{0}`
+            given the true state should be :math:`\\ket{1}`.
         id_: Identifier of the chip sample. Defaults to None.
 
     Example:
@@ -57,6 +62,9 @@ class IQMErrorProfile:
                 two_qubit_gate_depolarizing_error_parameters={"cz": {("QB1", "QB2"): 0.08, ("QB2", "QB3"): 0.03}},
                 single_qubit_gate_durations={"r": 50.},
                 two_qubit_gate_durations={"cz": 100.},
+                readout_errors={"QB1": {"0": 0.02, "1": 0.03},
+                                "QB2": {"0": 0.02, "1": 0.03},
+                                "QB3": {"0": 0.02, "1": 0.03}},
                 id_="threequbit-example_sample"
             )
     """
@@ -67,6 +75,7 @@ class IQMErrorProfile:
     two_qubit_gate_depolarizing_error_parameters: dict[str, dict[tuple[str, str], float]]
     single_qubit_gate_durations: dict[str, float]
     two_qubit_gate_durations: dict[str, float]
+    readout_errors: dict[str, dict[str, float]]
     id_: Union[str, None] = None
 
 
@@ -186,6 +195,12 @@ class IQMFakeBackend(IQMBackendBase):
                             f"Valid gates: {architecture.operations}"
                         )
                     )
+        if set(error_profile.readout_errors.keys()) != set(architecture.qubits):
+            raise ValueError(
+                f"The qubits specified in readout errors ({set(error_profile.readout_errors.keys())}) "
+                f"don't match the qubits of the quantum architecture "
+                f"`{architecture.name}` ({architecture.qubits})."
+            )
 
     def _create_noise_model(
         self, architecture: QuantumArchitectureSpecification, error_profile: IQMErrorProfile
@@ -230,6 +245,11 @@ class IQMFakeBackend(IQMBackendBase):
                     IQM_TO_QISKIT_GATE_NAME[gate],
                     [self.qubit_name_to_index(qb1), self.qubit_name_to_index(qb2)],
                 )
+
+        # Add readout errors
+        for qb, readout_error in error_profile.readout_errors.items():
+            probabilities = [[1 - readout_error["0"], readout_error["0"]], [readout_error["1"], 1 - readout_error["1"]]]
+            noise_model.add_readout_error(probabilities, [self.qubit_name_to_index(qb)])
 
         return noise_model
 

--- a/tests/fake_backends/conftest.py
+++ b/tests/fake_backends/conftest.py
@@ -31,6 +31,11 @@ def create_3q_error_profile():
             "two_qubit_gate_depolarizing_error_parameters": {"cz": {("QB1", "QB2"): 0.001, ("QB2", "QB3"): 0.001}},
             "single_qubit_gate_durations": {"phased_rx": 1.0},
             "two_qubit_gate_durations": {"cz": 1.5},
+            "readout_errors": {
+                "QB1": {"0": 0.02, "1": 0.03},
+                "QB2": {"0": 0.02, "1": 0.03},
+                "QB3": {"0": 0.02, "1": 0.03},
+            },
             "id_": "adonis-example_sample",
         }
         error_profile_contents.update(kwargs)

--- a/tests/fake_backends/test_iqm_fake_backend.py
+++ b/tests/fake_backends/test_iqm_fake_backend.py
@@ -207,3 +207,20 @@ def test_noise_model_has_noise_terms(backend):
     noise_model = backend.noise_model
 
     assert not noise_model.is_ideal()
+
+
+def test_fake_backend_with_readout_errors_more_qubits_than_in_quantum_architecture(
+    linear_architecture_3q,
+    create_3q_error_profile,
+):
+    """Test that ChipSample construction fails if readout errors are provided for
+    other qubits than specified in the quantum architecture"""
+    with pytest.raises(ValueError, match="The qubits specified in readout errors"):
+        error_profile = create_3q_error_profile(
+            readout_errors={
+                "QB1": {"0": 0.02, "1": 0.03},
+                "QB2": {"0": 0.02, "1": 0.03},
+                "QB4": {"0": 0.02, "1": 0.03},
+            },
+        )
+        IQMFakeBackend(linear_architecture_3q, error_profile)


### PR DESCRIPTION
Added readout errors to noise model. This includes:
- New attribute in `IQMErrorProfile` dataclass.
- Added readout errors to noise model in `IQMFakeBackend` class.
- Added information to docstring of `IQMFakeBackend` class.
- Added parameter values for readout errors to `IQMFakeAdonis`.
- Improved wording in user guide section.
- Added test case.