### PR TITLE
Clarify parameters, update terminology

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -23,9 +23,8 @@ things are set up correctly:
 2. Install Qiskit on IQM as instructed below (feel free to skip the import statement)
 3. Install Cortex CLI and log in as instructed in the `documentation <https://iqm-finland.github.io/cortex-cli/readme.html#installing-cortex-cli>`__
 4. Set the environment variable as instructed by Cortex CLI after logging in
-5. Run ``$ python bell_measure.py --server_url https://demo.qc.iqm.fi/cocos`` – replace the example URL with the correct one
+5. Run ``$ python bell_measure.py --cortex_server_url https://demo.qc.iqm.fi/cocos`` – replace the example URL with the correct one
 6. If you're connecting to a real quantum computer, the output should show almost half of the measurements resulting in '00' and almost half in '11' – if this is the case, things are set up correctly!
-7. Alternatively, add flag ``--backend facade_adonis`` to submit the circuit to an IQM quantum computer for validation, but compute the results in a local Adonis simulator; the output should be similar to the output from a real quantum computer
 
 
 Installation
@@ -234,15 +233,15 @@ can create a copy of the fake Adonis instance with updated error profile:
 Running a quantum circuit on a facade backend
 ---------------------------------------------
 
-Circuits can be executed against a "simulated" environment: an IQM server that has no real quantum computer hardware.
+Circuits can be executed against a mock environment: an IQM server that has no real quantum computer hardware.
 Results from such executions are random bits. This may be useful when developing and testing software integrations.
 
-Qiskit on IQM contains :class:`.IQMFacadeBackend`, which allows to combine the "simulated" remote execution with a local
+Qiskit on IQM contains :class:`.IQMFacadeBackend`, which allows to combine the mock remote execution with a local
 noisy quantum circuit simulation. This way you can both validate your integration as well as get an idea of the expected circuit execution results.
 
 To run a circuit this way, use the `facade_adonis` backend retrieved from the provider. Note that the provider must be
 initialized with the URL of a quantum computer with the equivalent architecture (i.e. names of qubits, their
-connectivity and supported gates should match the 5-qubit Adonis architecture).
+connectivity, and the native gateset should match the 5-qubit Adonis architecture).
 
 .. code-block:: python
 

--- a/examples/bell_measure.py
+++ b/examples/bell_measure.py
@@ -23,14 +23,16 @@ from qiskit import QuantumCircuit, execute
 from qiskit_iqm import IQMProvider
 
 argparser = argparse.ArgumentParser()
-argparser.add_argument('--server_url', help='URL of the IQM server', default='https://demo.qc.iqm.fi/cocos')
-argparser.add_argument('--backend', help='Whether to use custom backend, e.g. facade_adonis', default=None)
+argparser.add_argument(
+    '--cortex_server_url',
+    help='URL of the IQM Cortex server',
+    default='https://demo.qc.iqm.fi/cocos',
+)
 server_url = argparser.parse_args().server_url
-backend_name = argparser.parse_args().backend
 
 circuit = QuantumCircuit(2)
 circuit.h(0)
 circuit.cx(0, 1)
 circuit.measure_all()
 
-print(execute(circuit, IQMProvider(server_url).get_backend(backend_name), shots=1000).result().get_counts())
+print(execute(circuit, IQMProvider(server_url).get_backend(), shots=1000).result().get_counts())


### PR DESCRIPTION
* Make the server URL parameter name consistent with the documentation and other libraries
* Remove an option unsuitable for the "Hello, world!" example
* Update the mock environment terminology