### PR TITLE
Bugfix: Handle case where heralding returns zero shots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 8.3
+============
+
+* Bugfixes for ``heralding`` run with zero shots returned. `#65 <https://github.com/iqm-finland/qiskit-on-iqm/pull/65>`_
+* Allow specifying ``calibration_set_id`` both as string and as ``UUID``. `#65 <https://github.com/iqm-finland/qiskit-on-iqm/pull/65>`_
+
 Version 8.2
 ============
 

--- a/src/qiskit_iqm/iqm_job.py
+++ b/src/qiskit_iqm/iqm_job.py
@@ -69,7 +69,10 @@ class IQMJob(JobV1):
             mk = MeasurementKey.from_string(k)
             res = np.array(v, dtype=int)
             if len(v) == 0 and not expect_exact_shots:
-                warnings.warn('Received measurement results with zero results')
+                warnings.warn(
+                    'Received measurement results containing zero shots. '
+                    'In case you are using non-default heralding mode, this could be because of bad calibration.'
+                )
                 res = np.array([])
             else:
                 # in Qiskit each measurement is a separate single-qubit instruction. qiskit-iqm assigns unique

--- a/src/qiskit_iqm/iqm_provider.py
+++ b/src/qiskit_iqm/iqm_provider.py
@@ -64,6 +64,8 @@ class IQMBackend(IQMBackendBase):
 
         shots = options.get('shots', self.options.shots)
         calibration_set_id = options.get('calibration_set_id', self.options.calibration_set_id)
+        if calibration_set_id is not None and not isinstance(calibration_set_id, UUID):
+            calibration_set_id = UUID(calibration_set_id)
         circuit_duration_check = options.get('circuit_duration_check', self.options.circuit_duration_check)
         heralding_mode = options.get('heralding_mode', self.options.heralding_mode)
 
@@ -75,7 +77,7 @@ class IQMBackend(IQMBackendBase):
         job_id = self.client.submit_circuits(
             circuits_serialized,
             qubit_mapping=qubit_mapping,
-            calibration_set_id=UUID(calibration_set_id) if calibration_set_id else None,
+            calibration_set_id=calibration_set_id if calibration_set_id else None,
             shots=shots,
             circuit_duration_check=circuit_duration_check,
             heralding_mode=heralding_mode,

--- a/tests/test_iqm_job.py
+++ b/tests/test_iqm_job.py
@@ -134,7 +134,8 @@ def test_result_no_shots(job, iqm_result_no_shots, iqm_metadata):
     )
     when(job._client).wait_for_results(uuid.UUID(job.job_id())).thenReturn(client_result)
 
-    result = job.result()
+    with pytest.warns(UserWarning, match='Received measurement results containing zero shots.'):
+        result = job.result()
 
     assert isinstance(result, QiskitResult)
     assert result.get_memory() == []

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -271,12 +271,16 @@ def test_run_sets_circuit_metadata_to_the_job(backend):
     assert job.circuit_metadata == [circuit_1.metadata, circuit_2.metadata]
 
 
-def test_run_with_custom_calibration_set_id(backend, circuit, submit_circuits_default_kwargs, job_id):
+@pytest.mark.parametrize(
+    'calibration_set_id', ['67e77465-d90e-4839-986e-9270f952b743', uuid.UUID('67e77465-d90e-4839-986e-9270f952b743')]
+)
+def test_run_with_custom_calibration_set_id(
+    backend, circuit, submit_circuits_default_kwargs, job_id, calibration_set_id
+):
     circuit.measure(0, 0)
     circuit_ser = backend.serialize_circuit(circuit)
-    calibration_set_id = '67e77465-d90e-4839-986e-9270f952b743'
     kwargs = submit_circuits_default_kwargs | {
-        'calibration_set_id': uuid.UUID(calibration_set_id),
+        'calibration_set_id': uuid.UUID('67e77465-d90e-4839-986e-9270f952b743'),
         'qubit_mapping': {'0': 'QB1'},
     }
     when(backend.client).submit_circuits([circuit_ser], **kwargs).thenReturn(job_id)


### PR DESCRIPTION
This MR fixes two small issues:
* Handle case where heralding returns zero shots
* Handle cal set id both as str and UUID