### PR TITLE
Fixed 2QB gate error depending on qubit order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 10.8
+============
+
+* Fix two-qubit gate error construction in ``IQMFakeBackend``.
+
 Version 10.7
 ============
 

--- a/tests/fake_backends/test_iqm_fake_backend.py
+++ b/tests/fake_backends/test_iqm_fake_backend.py
@@ -227,3 +227,6 @@ def test_noise_model_contains_all_errors(backend):
     Test that the noise model contains all necessary errors.
     """
     assert set(backend.noise_model.noise_instructions) == {"r", "cz", "measure"}
+
+    # Assert that CZ gate error is applied independent of argument order in gate specification
+    assert set(backend.noise_model._local_quantum_errors["cz"].keys()) == set([(0, 1), (1, 0), (1, 2), (2, 1)])


### PR DESCRIPTION
Errors to two-qubit `CZ` gates were only applied for one specific order of the qubit arguments in the gate construction. But the error should be applied independent of this order since the gate is symmetric in control and target qubit.

Changes:

- Added reverse qubit order in error construction in `iqm_fake_backend.py`.
- Added assertion to test case `test_noise_model_contains_all_errors` in `test_iqm_fake_backend.py`.