### PR TITLE
Some unrelated small updates and fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 10.10
+=============
+
+* Upgrade to qiskit ~= 0.44.1. `#77 <https://github.com/iqm-finland/qiskit-on-iqm/pull/77>`
+* Make the ``max_circuits`` property of ``IQMBackend`` user-configurable. `#77 <https://github.com/iqm-finland/qiskit-on-iqm/pull/77>`
+* Implement ``error_message`` method for ``IQMJob``. `#77 <https://github.com/iqm-finland/qiskit-on-iqm/pull/77>``
+* Explicitly specify symmetric CZ properties when building the transpilation target. `#77 <https://github.com/iqm-finland/qiskit-on-iqm/pull/77>`
+
 Version 10.9
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 requires-python = ">=3.9, <3.12"
 dependencies = [
     "numpy",
-    "qiskit ~= 0.42.1",
+    "qiskit ~= 0.44.1",
+    "qiskit-aer ~= 0.12.2",
     "iqm-client >= 13.2, < 14.0"
 ]
 

--- a/src/qiskit_iqm/iqm_backend.py
+++ b/src/qiskit_iqm/iqm_backend.py
@@ -53,8 +53,16 @@ class IQMBackendBase(BackendV2, ABC):
             RGate(Parameter('theta'), Parameter('phi')), {(qb_to_idx[qb],): None for qb in architecture.qubits}
         )
         target.add_instruction(IGate(), {(qb_to_idx[qb],): None for qb in architecture.qubits})
+        # Even though CZ is a symmetric gate, we still need to add properties for both directions. This is because
+        # coupling maps in Qiskit are directed graphs and the gate symmetry is not implicitly planted there. It should
+        # be explicitly supplied. This allows Qiskit to have coupling maps with non-symmetric gates like cx.
         target.add_instruction(
-            CZGate(), {(qb_to_idx[qb1], qb_to_idx[qb2]): None for qb1, qb2 in architecture.qubit_connectivity}
+            CZGate(),
+            {
+                (qb_to_idx[qb1], qb_to_idx[qb2]): None
+                for pair in architecture.qubit_connectivity
+                for qb1, qb2 in (pair, pair[::-1])
+            },
         )
         target.add_instruction(Measure(), {(qb_to_idx[qb],): None for qb in architecture.qubits})
 

--- a/src/qiskit_iqm/iqm_job.py
+++ b/src/qiskit_iqm/iqm_job.py
@@ -181,3 +181,7 @@ class IQMJob(JobV1):
         if result.status == Status.ABORTED:
             return JobStatus.CANCELLED
         raise RuntimeError(f"Unknown run status '{result.status}'")
+
+    def error_message(self) -> Optional[str]:
+        """Returns the error message if job has failed, otherwise returns None."""
+        return self._client.get_run_status(uuid.UUID(self._job_id)).message

--- a/src/qiskit_iqm/iqm_provider.py
+++ b/src/qiskit_iqm/iqm_provider.py
@@ -48,7 +48,8 @@ class IQMBackend(IQMBackendBase):
 
     def __init__(self, client: IQMClient, **kwargs):
         super().__init__(client.get_quantum_architecture(), **kwargs)
-        self.client = client
+        self.client: IQMClient = client
+        self._max_circuits: Optional[int] = None
 
     @classmethod
     def _default_options(cls) -> Options:
@@ -58,7 +59,17 @@ class IQMBackend(IQMBackendBase):
 
     @property
     def max_circuits(self) -> Optional[int]:
-        return None
+        return self._max_circuits
+
+    @max_circuits.setter
+    def max_circuits(self, value: Optional[int]) -> None:
+        """Set the max_circuits property to a custom value.
+
+        Generally, this property is set automatically during the construction of backend instance. However, in certain
+        situations (mostly when using qiskit_experiments), user wants to have control over how many circuits are
+        included in a single batch. This setter method makes it easy to override the default value with desired one.
+        """
+        self._max_circuits = value
 
     def run(self, run_input: Union[QuantumCircuit, list[QuantumCircuit]], **options) -> IQMJob:
         if self.client is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,8 @@ def adonis_architecture_shuffled_names():
         qubits=['QB2', 'QB3', 'QB1', 'QB5', 'QB4'],
         qubit_connectivity=[['QB1', 'QB3'], ['QB2', 'QB3'], ['QB4', 'QB3'], ['QB5', 'QB3']],
     )
+
+
+@pytest.fixture
+def adonis_coupling_map():
+    return {(0, 2), (2, 0), (1, 2), (2, 1), (2, 3), (3, 2), (2, 4), (4, 2)}

--- a/tests/fake_backends/test_fake_adonis.py
+++ b/tests/fake_backends/test_fake_adonis.py
@@ -24,9 +24,9 @@ def test_iqm_fake_adonis():
     assert backend.num_qubits == 5
 
 
-def test_iqm_fake_adonis_connectivity():
+def test_iqm_fake_adonis_connectivity(adonis_coupling_map):
     backend = IQMFakeAdonis()
-    assert backend.coupling_map.get_edges() == [(0, 2), (1, 2), (2, 3), (2, 4)]
+    assert set(backend.coupling_map.get_edges()) == adonis_coupling_map
 
 
 def test_iqm_fake_adonis_noise_model_instantiated():

--- a/tests/test_iqm_job.py
+++ b/tests/test_iqm_job.py
@@ -143,6 +143,21 @@ def test_other_job_statuses(job, run_status: Status, job_status: JobStatus):
     assert job.status() == job_status
 
 
+def test_error_message(job, iqm_metadata):
+    err_msg = 'The job failed with this error message'
+    client_result = RunResult(status=Status.FAILED, message=err_msg, metadata=iqm_metadata)
+    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenReturn(client_result)
+    assert job.status() == JobStatus.ERROR
+    assert job.error_message() == err_msg
+
+
+def test_error_message_on_successful_job(job, iqm_metadata):
+    client_result = RunResult(status=Status.READY, metadata=iqm_metadata)
+    when(job._client).get_run_status(uuid.UUID(job.job_id())).thenReturn(client_result)
+    assert job.status() == JobStatus.DONE
+    assert job.error_message() is None
+
+
 def test_result(job, iqm_result_two_registers, iqm_metadata):
     client_result = RunResult(
         status=Status.READY,

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -371,7 +371,7 @@ def test_get_backend(linear_architecture_3q):
     assert isinstance(backend, IQMBackend)
     assert backend.client._base_url == url
     assert backend.num_qubits == 3
-    assert set(backend.coupling_map.get_edges()) == {(0, 1), (1, 2)}
+    assert set(backend.coupling_map.get_edges()) == {(0, 1), (1, 0), (1, 2), (2, 1)}
 
 
 def test_client_signature():
@@ -381,7 +381,7 @@ def test_client_signature():
     assert f'qiskit-iqm {version("qiskit-iqm")}' in backend.client._signature
 
 
-def test_get_facade_backend(adonis_architecture):
+def test_get_facade_backend(adonis_architecture, adonis_coupling_map):
     url = 'http://some_url'
     when(IQMClient).get_quantum_architecture().thenReturn(adonis_architecture)
 
@@ -391,7 +391,7 @@ def test_get_facade_backend(adonis_architecture):
     assert isinstance(backend, IQMFacadeBackend)
     assert backend.client._base_url == url
     assert backend.num_qubits == 5
-    assert set(backend.coupling_map.get_edges()) == {(0, 2), (1, 2), (3, 2), (4, 2)}
+    assert set(backend.coupling_map.get_edges()) == adonis_coupling_map
 
 
 def test_get_facade_backend_raises_error_non_matching_architecture(linear_architecture_3q):

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -77,8 +77,18 @@ def test_retrieve_job(backend):
     assert job.job_id() == 'a job id'
 
 
-def test_max_circuits(backend):
+def test_default_max_circuits(backend):
     assert backend.max_circuits is None
+
+
+def test_set_max_circuits(backend):
+    assert backend.max_circuits is None
+
+    backend.max_circuits = 17
+    assert backend.max_circuits == 17
+
+    backend.max_circuits = 168
+    assert backend.max_circuits == 168
 
 
 def test_qubit_name_to_index_to_qubit_name(adonis_architecture_shuffled_names):

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -15,7 +15,6 @@
 """Testing IQM provider.
 """
 from importlib.metadata import version
-from numbers import Number
 import uuid
 
 from iqm_client import HeraldingMode, IQMClient, RunResult, RunStatus
@@ -23,7 +22,7 @@ from mockito import ANY, mock, patch, when
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit, execute
-from qiskit.circuit import Parameter, ParameterExpression
+from qiskit.circuit import Parameter
 from qiskit.circuit.library import RGate
 from qiskit.compiler import transpile
 
@@ -143,25 +142,6 @@ def test_serialize_circuit_maps_r_gate(circuit, gate, expected_angle, expected_p
     # Serialized angles should be in full turns
     assert instr.args['angle_t'] == expected_angle
     assert instr.args['phase_t'] == expected_phase
-
-
-def test_serialize_handles_parameter_expressions(circuit, backend):
-    theta = Parameter('θ')
-    phi = Parameter('φ')
-    circuit.r(theta, phi, 0)
-    circuit_bound = circuit.bind_parameters({theta: np.pi, phi: 0})
-
-    # First make sure that circuit_bound does indeed represent parameters as ParameterExpression
-    assert len(circuit_bound.data) == 1
-    instruction = circuit_bound.data[0][0]
-    assert all(isinstance(param, ParameterExpression) for param in instruction.params)
-
-    # Now check that serialization correctly handles ParameterExpression
-    circuit_ser = backend.serialize_circuit(circuit_bound)
-    assert len(circuit_ser.instructions) == 1
-    iqm_instruction = circuit_ser.instructions[0]
-    assert isinstance(iqm_instruction.args['angle_t'], Number)
-    assert isinstance(iqm_instruction.args['phase_t'], Number)
 
 
 def test_serialize_circuit_maps_cz_gate(circuit, backend):


### PR DESCRIPTION
* **Upgrade to qiskit ~= 0.44.1.** Qiskit has changed a lot since last time our dependency was bumped, so its time to follow along. Some notable changes:
  * There is no `qiskit-terra` anymore - it was just merged into the main `qiskit` package.
  * `qiskit-aer` no longer gets installed by default when installing qiskit, so now we have to have explicit dependency on it, since fake backend uses it.
  * When binding numeric values to `ParameterExpression`s, the result is actually the number itself. Previously it would still remain a `ParameterExpression`, that contained a number and you had to cast it to float.
* Make the ``max_circuits`` property of ``IQMBackend`` user-configurable. Explained in the inline comment.
* Implement ``error_message`` method for ``IQMJob``. Some code in `qiskit_experiments` relies on the existence of this method, even though it is not part of the `Job` interface. Will report this to Qiskit devs.
* Explicitly specify symmetric CZ properties when building the transpilation target. Explained in the inline comment