### PR TITLE
IQMBackend improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+Version 11.1
+============
+
+* Add ``circuit_callback`` option to ``IQMBackend``. `#80 <https://github.com/iqm-finland/qiskit-on-iqm/pull/80>`_
+* Raise error when unknown option is passed to ``IQMBackend.run``. Previously they were silently ignored. `#80 <https://github.com/iqm-finland/qiskit-on-iqm/pull/80>`_
+* Improve handling of options passed to ``IQMBackend.run``. `#80 <https://github.com/iqm-finland/qiskit-on-iqm/pull/80>`_
+* Fix the type of ``date`` in result object. `#80 <https://github.com/iqm-finland/qiskit-on-iqm/pull/80>`_
+* ``IQMBackend.run`` can now accept circuits containing `x`, `rx`, `y` and `ry` gates. `#80 <https://github.com/iqm-finland/qiskit-on-iqm/pull/80>`_
+
 Version 11.0
 ============
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -139,6 +139,17 @@ their current values using `backend.options`. Below table summarizes currently a
      - :py:class:`~iqm_client.iqm_client.HeraldingMode`
      - "zeros"
      - Heralding mode to use during execution. The default value is "none".
+   * - `circuit_callback`
+     - :py:class:`collections.abc.Callable`
+     - ``None``
+     - A function that accepts a list of :py:class:`qiskit.QuantumCircuit` instances and does not return anything.
+       When the backend receives circuits for execution, it will call this function (if provided) and pass those
+       circuits as argument. This may be useful in situations when you do not have explicit control over transpilation,
+       but need some information on how it was done. This can happen, for example, when you use pre-implemented
+       algorithms and experiments in Qiskit, where the implementation of the said algorithm or experiment takes care of
+       delivering correctly transpiled circuits to the backend. This callback method gives you a chance to look into
+       those transpiled circuits, extract any info you need.
+
 
 If the IQM server you are connecting to requires authentication, you will also have to use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -146,7 +146,8 @@ their current values using `backend.options`. Below table summarizes currently a
        but need some information on how it was done. This can happen, for example, when you use pre-implemented
        algorithms and experiments in Qiskit, where the implementation of the said algorithm or experiment takes care of
        delivering correctly transpiled circuits to the backend. This callback method gives you a chance to look into
-       those transpiled circuits, extract any info you need.
+       those transpiled circuits, extract any info you need. As a side effect, you can also use this callback to modify
+       the transpiled circuits in-place, just before execution, however we do not recommend to use it for this purpose.
 
 
 If the IQM server you are connecting to requires authentication, you will also have to use

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -112,37 +112,35 @@ and then call execution methods without specifying additional keyword arguments.
 their current values using `backend.options`. Below table summarizes currently available options:
 
 .. list-table::
-   :widths: 25 20 25 100
+   :widths: 25 100
    :header-rows: 1
 
    * - Name
-     - Type
-     - Example value
      - Description
    * - `shots`
-     - int
-     - 1207
-     - Number of shots.
+     - Type: ``int``, Example value: ``1207``.
+
+       Number of shots.
    * - `calibration_set_id`
-     - str
-     - "f7d9642e-b0ca-4f2d-af2a-30195bd7a76d"
-     - Indicates the calibration set to use. Defaults to `None`, which means the IQM server will use the best
+     - Type: ``str``, Example value ``"f7d9642e-b0ca-4f2d-af2a-30195bd7a76d"``.
+
+       Indicates the calibration set to use. Defaults to `None`, which means the IQM server will use the best
        available calibration set automatically.
    * - `circuit_duration_check`
-     - bool
-     - False
-     - Enable or disable server-side circuit duration checks. The default value is `True`, which means if any job is
+     - Type: ``bool``, Example value: ``False``.
+
+       Enable or disable server-side circuit duration checks. The default value is `True`, which means if any job is
        estimated to take unreasonably long compared to the coherence times of the qubits, or too long in wall-clock
        time, the server will reject it. This option can be used to disable this behaviour. In normal use, the
        circuit duration check should always remain enabled.
    * - `heralding_mode`
-     - :py:class:`~iqm_client.iqm_client.HeraldingMode`
-     - "zeros"
-     - Heralding mode to use during execution. The default value is "none".
+     - Type: :class:`~iqm.iqm_client.iqm_client.HeraldingMode`, Example value: ``"zeros"``.
+
+       Heralding mode to use during execution. The default value is "none".
    * - `circuit_callback`
-     - :py:class:`collections.abc.Callable`
-     - ``None``
-     - A function that accepts a list of :py:class:`qiskit.QuantumCircuit` instances and does not return anything.
+     - Type: :class:`collections.abc.Callable`, Example value: ``None``.
+
+       A function that accepts a list of :class:`qiskit.QuantumCircuit` instances and does not return anything.
        When the backend receives circuits for execution, it will call this function (if provided) and pass those
        circuits as argument. This may be useful in situations when you do not have explicit control over transpilation,
        but need some information on how it was done. This can happen, for example, when you use pre-implemented

--- a/src/iqm/qiskit_iqm/iqm_job.py
+++ b/src/iqm/qiskit_iqm/iqm_job.py
@@ -159,7 +159,7 @@ class IQMJob(JobV1):
                 }
                 for i, (name, measurement_results) in enumerate(self._result)
             ],
-            'date': date.today(),
+            'date': date.today().isoformat(),
             'request': self._request,
             'timestamps': self.metadata.get('timestamps'),
         }

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Qiskit Backend Provider for IQM backends.
 """
+from copy import copy
 from importlib.metadata import PackageNotFoundError, version
 from functools import reduce
 from typing import Optional, Union
@@ -88,14 +89,17 @@ class IQMBackend(IQMBackendBase):
         if unknown_options:
             raise ValueError(f'Unknown backend option(s): {unknown_options}')
 
-        shots = options.get('shots', self.options.shots)
-        calibration_set_id = options.get('calibration_set_id', self.options.calibration_set_id)
+        # merge given options with default options and get resulting values
+        merged_options = copy(self.options)
+        merged_options.update_options(**dict(options))
+        shots = merged_options['shots']
+        calibration_set_id = merged_options['calibration_set_id']
         if calibration_set_id is not None and not isinstance(calibration_set_id, UUID):
             calibration_set_id = UUID(calibration_set_id)
-        circuit_duration_check = options.get('circuit_duration_check', self.options.circuit_duration_check)
-        heralding_mode = options.get('heralding_mode', self.options.heralding_mode)
+        circuit_duration_check = merged_options['circuit_duration_check']
+        heralding_mode = merged_options['heralding_mode']
 
-        circuit_callback = options.get('circuit_callback', self.options.circuit_callback)
+        circuit_callback = merged_options['circuit_callback']
         if circuit_callback:
             circuit_callback(circuits)
 

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -54,7 +54,11 @@ class IQMBackend(IQMBackendBase):
     @classmethod
     def _default_options(cls) -> Options:
         return Options(
-            shots=1024, calibration_set_id=None, circuit_duration_check=True, heralding_mode=HeraldingMode.NONE
+            shots=1024,
+            calibration_set_id=None,
+            circuit_duration_check=True,
+            heralding_mode=HeraldingMode.NONE,
+            circuit_callback=None,
         )
 
     @property
@@ -86,6 +90,10 @@ class IQMBackend(IQMBackendBase):
             calibration_set_id = UUID(calibration_set_id)
         circuit_duration_check = options.get('circuit_duration_check', self.options.circuit_duration_check)
         heralding_mode = options.get('heralding_mode', self.options.heralding_mode)
+
+        circuit_callback = options.get('circuit_callback', self.options.circuit_callback)
+        if circuit_callback:
+            circuit_callback(circuits)
 
         circuits_serialized: list[Circuit] = [self.serialize_circuit(circuit) for circuit in circuits]
         used_indices: set[int] = reduce(

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -84,6 +84,10 @@ class IQMBackend(IQMBackendBase):
         if len(circuits) == 0:
             raise ValueError('Empty list of circuits submitted for execution.')
 
+        unknown_options = set(options.keys()) - set(self.options.keys())
+        if unknown_options:
+            raise ValueError(f'Unknown backend option(s): {unknown_options}')
+
         shots = options.get('shots', self.options.shots)
         calibration_set_id = options.get('calibration_set_id', self.options.calibration_set_id)
         if calibration_set_id is not None and not isinstance(calibration_set_id, UUID):

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -354,6 +354,7 @@ def test_run_with_heralding_mode_zeros(backend, circuit, submit_circuits_default
     backend.run([circuit], heralding_mode='zeros')
 
 
+# mypy: disable-error-code="attr-defined"
 def test_run_with_circuit_callback(backend, job_id, submit_circuits_default_kwargs):
     qc1 = QuantumCircuit(3)
     qc1.measure_all()
@@ -367,10 +368,14 @@ def test_run_with_circuit_callback(backend, job_id, submit_circuits_default_kwar
         assert len(circuits) == 2
         assert circuits[0].name == qc1.name
         assert circuits[1].name == qc2.name
+        sample_callback.called = True
+
+    sample_callback.called = False
 
     kwargs = submit_circuits_default_kwargs | {'qubit_mapping': {'0': 'QB1', '1': 'QB2', '2': 'QB3'}}
     when(backend.client).submit_circuits(ANY, **kwargs).thenReturn(job_id)
     backend.run([qc1, qc2], circuit_callback=sample_callback)
+    assert sample_callback.called is True
 
 
 def test_run_with_unknown_option(backend, circuit):


### PR DESCRIPTION
- Adds a new option called `circuit_callback` to `IQMBackend`. Description and motivation is in the user guide.
- Unknown options passed to backend now cause an error. Previously they were just silently ignored, which was not good. E.g. if you wanted to specify custom calset ID, but you made a typo in the name of the option, it would get ignored and the default calibration set would be still used. And you would be left wondering why your calibration set is not being used. Now you will immediately get error that you have not supplied a correct option.
- Handling of options is now improved a bit and the code is easier to read and consume.
- Fix the type of ``date`` in result object. Qiskit expects it to be string. It was datetime before.
- ``IQMBackend`` can now serialize `x`, `rx`, `y` and `ry` gates as well. More details and motivation in the docstring of the serialize function.
- Improved the layout of user guide.