### PR TITLE
Emit warning instead of raising error for unknown options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 11.2
+============
+
+* Raise warning instead of error when unknown option is passed to ``IQMBackend.run``. `#82 <https://github.com/iqm-finland/qiskit-on-iqm/pull/82>`_
+
+
 Version 11.1
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ testing = [
     "isort == 5.10.1",
     "mockito == 1.3.0",
     "mypy == 0.982",
+    "pylint == 2.17.6",
     "pytest == 7.0.1",
     "pytest-cov == 3.0.0",
     "pytest-isort == 3.0.0",

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -87,7 +87,7 @@ class IQMBackend(IQMBackendBase):
 
         unknown_options = set(options.keys()) - set(self.options.keys())
         if unknown_options:
-            raise ValueError(f'Unknown backend option(s): {unknown_options}')
+            warnings.warn(f'Unknown backend option(s): {unknown_options}')
 
         # merge given options with default options and get resulting values
         merged_options = copy(self.options)

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -378,9 +378,10 @@ def test_run_with_circuit_callback(backend, job_id, submit_circuits_default_kwar
     assert sample_callback.called is True
 
 
-def test_run_with_unknown_option(backend, circuit):
+def test_run_with_unknown_option(backend, circuit, job_id):
     circuit.measure_all()
-    with pytest.raises(ValueError, match=r'Unknown backend option\(s\)'):
+    when(backend.client).submit_circuits(...).thenReturn(job_id)
+    with pytest.warns(Warning, match=r'Unknown backend option\(s\)'):
         backend.run(circuit, to_option_or_not_to_option=17)
 
 


### PR DESCRIPTION
- https://github.com/iqm-finland/qiskit-on-iqm/pull/80 introduced errors for scenarios when user provides unknown options to the backend. This is too restrictive and causes some unnecessary work in some cases, e.g. running QV experiments. Warning the user about unknown options should be enough. 
- `pylint` released a new major version overnight, and our test dependency on `pytest_pylint` installs it, then causes errors during the running of tests, because of incompatibility. Since `pytest_pylint` does not yet have an upgrade to support this new version, I had to pin the pylint version in the dependencies as well.