### PR TITLE
Use GitHub Action Trusted Publisher for PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,13 @@
-name: Upload to PyPI and publish documentation
+name: Upload package to PyPI and publish documentation
 
 on:
   release:
     types: [published]
   workflow_dispatch:
   workflow_call:
-    secrets:
-      PYPI_USER:
-        required: true
-      PYPI_PASSWORD:
-        required: true
 
 jobs:
-  push_to_pypi:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,15 +21,30 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,cicd]"
-      - name: Build and publish
-        run: |
-          tox -e build
-          python -m twine check dist/*
-          python -m twine upload dist/*
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          python -m pip install build==1.0.3
+      - name: Build distribution
+        run: python -m build
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist
+
+  push_to_pypi:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qiskit-iqm
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v4
+      - name: Publish distribution packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   publish_docs:
     runs-on: ubuntu-latest
@@ -84,7 +94,7 @@ jobs:
           pip-licenses --format=confluence --with-urls > licenses.txt
           cat -n licenses.txt | sort -uk2 | sort -n | cut -f2- > tmp && mv tmp licenses.txt  # remove duplicate lines
       - name: Upload license information artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dependencies-licenses
           path: licenses.txt

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -40,7 +40,4 @@ jobs:
   # created by the above job create_tag_and_release. Here we trigger the said workflow manually.
   trigger_publishing:
     needs: create_tag_and_release
-    uses: iqm-finland/qiskit-on-iqm/.github/workflows/publish.yml@main
-    secrets:
-      PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    uses: ./.github/workflows/publish.yml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,15 @@
 Changelog
 =========
 
+Version 12.2
+============
+
+* Use GitHub Action as a Trusted Publisher to publish packages to PyPI. `#94 <https://github.com/iqm-finland/qiskit-on-iqm/pull/94>`_
+
 Version 12.1
 ============
 
-* Remove multiversion documentation `#92 <https://github.com/iqm-finland/qiskit-on-iqm/pull/92>`_
+* Remove multiversion documentation. `#92 <https://github.com/iqm-finland/qiskit-on-iqm/pull/92>`_
 
 Version 12.0
 ============
@@ -23,12 +28,12 @@ Version 11.10
 Version 11.9
 ============
 
-* Add ``name`` to backends `#88 <https://github.com/iqm-finland/qiskit-on-iqm/pull/88>`_
+* Add ``name`` to backends. `#88 <https://github.com/iqm-finland/qiskit-on-iqm/pull/88>`_
 
 Version 11.8
 ============
 
-* Add ``IQMFakeApollo`` fake backend `#66 <https://github.com/iqm-finland/qiskit-on-iqm/pull/66>`_
+* Add ``IQMFakeApollo`` fake backend. `#66 <https://github.com/iqm-finland/qiskit-on-iqm/pull/66>`_
 
 Version 11.7
 ============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ changelog = "https://github.com/iqm-finland/qiskit-on-iqm/blob/main/CHANGELOG.rs
 
 [project.optional-dependencies]
 # Add here additional requirements for extra features, to install with:
-# `pip install qiskit-iqm[dev,docs,testing,cicd]
+# `pip install qiskit-iqm[dev,docs,testing]
 dev = [
     "tox == 4.11.4"
 ]
@@ -51,9 +51,6 @@ testing = [
     "pytest-cov == 4.1.0",
     "pytest-pylint == 0.21.0",
     "types-Jinja2 == 2.11.9"
-]
-cicd = [
-    "twine == 4.0.2"
 ]
 
 


### PR DESCRIPTION
- Separate ```push_to_pypi``` job into two jobs: ```build``` and ```push_to_pypi```
- Use ```publish``` workflow file from current feature branch rather than ```main``` branch
- Do not use ```tox``` in ```publish``` workflow to build and upload package
- Remove ```twine``` dependency
- Remove references to PyPI secrets
