### PR TITLE
COMP-1468 and SW-381

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 13.4
+============
+
+* Added the option to change the timeout between waiting for results when a job is submitted. Github issue `#108 <https://github.com/iqm-finland/qiskit-on-iqm/issues/108>`_
+* Added support for optional MOVE gate validation bypassing for advanced users. 
+* Updated requirement for ``iqm-client`` to version 17.8.
+
+
 Version 13.3
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "qiskit >= 0.45.1, < 0.46",
     "qiskit-aer >= 0.13.1, < 0.14",
-    "iqm-client >= 17.2, < 18.0"
+    "iqm-client >= 17.8, < 18.0"
 ]
 
 [project.urls]

--- a/tests/move_architecture/test_move_circuit.py
+++ b/tests/move_architecture/test_move_circuit.py
@@ -28,8 +28,14 @@ def test_move_gate_trivial_layout(new_architecture):
     qc.append(MoveGate(), [6, 0])
     qc.cz(0, 3)
     qc.cz(2, 0)
+    qc.append(MoveGate(), [6, 0])
     submitted_circuit = get_transpiled_circuit_json(qc, new_architecture)
-    assert [describe_instruction(i) for i in submitted_circuit.instructions] == ['move:6,0', 'cz:0,3', 'cz:2,0']
+    assert [describe_instruction(i) for i in submitted_circuit.instructions] == [
+        'move:6,0',
+        'cz:0,3',
+        'cz:2,0',
+        'move:6,0',
+    ]
 
 
 def test_move_gate_nontrivial_layout(new_architecture):
@@ -49,10 +55,11 @@ def test_mapped_move_qubit(new_architecture):
     initial layout using the IQMMoveLayout() layout pass.
     """
     qc = QuantumCircuit(7)
+    qc.append(MoveGate(), [3, 0])
     qc.cz(0, 2)
     qc.append(MoveGate(), [3, 0])
     submitted_circuit = get_transpiled_circuit_json(qc, new_architecture, create_move_layout=True)
-    assert [describe_instruction(i) for i in submitted_circuit.instructions] == ['cz:0,2', 'move:6,0']
+    assert [describe_instruction(i) for i in submitted_circuit.instructions] == ['move:6,0', 'cz:0,2', 'move:6,0']
 
 
 def test_mapped_move_qubit_and_resonator(new_architecture):
@@ -99,7 +106,6 @@ def test_transpiled_circuit(new_architecture):
     qc = IQMCircuit(7, 2)
     qc.move(6, 0)
     qc.cz(0, 3)
-    qc.h(6)
     qc.h(4)
     qc.cz(4, 0)
     qc.barrier()
@@ -118,8 +124,6 @@ def test_transpiled_circuit(new_architecture):
         # cz(4, 0) is optimized before h(6)
         'cz:4,0',
         # h(6)
-        'prx:6',
-        'prx:6',
         # barrier()
         'barrier:0,1,2,3,4,5,6',
         # move (6, 0)

--- a/tests/test_iqm_job.py
+++ b/tests/test_iqm_job.py
@@ -165,7 +165,7 @@ def test_result(job, iqm_result_two_registers, iqm_metadata):
         measurements=[iqm_result_two_registers],
         metadata=iqm_metadata,
     )
-    when(job._client).wait_for_results(uuid.UUID(job.job_id())).thenReturn(client_result)
+    when(job._client).wait_for_results(uuid.UUID(job.job_id()), job._timeout_seconds).thenReturn(client_result)
 
     result = job.result()
 
@@ -182,7 +182,8 @@ def test_result(job, iqm_result_two_registers, iqm_metadata):
     result = job.result()
     assert isinstance(result, QiskitResult)
     assert job.status() == JobStatus.DONE
-    mockito.verify(job._client, times=1).wait_for_results(uuid.UUID(job.job_id()))
+    mockito.verify(job._client, times=1).wait_for_results(uuid.UUID(job.job_id()), job._timeout_seconds)
+    assert job._timeout_seconds is not None
 
 
 def test_result_no_shots(job, iqm_result_no_shots, iqm_metadata):
@@ -192,7 +193,7 @@ def test_result_no_shots(job, iqm_result_no_shots, iqm_metadata):
         measurements=[iqm_result_no_shots],
         metadata=iqm_metadata,
     )
-    when(job._client).wait_for_results(uuid.UUID(job.job_id())).thenReturn(client_result)
+    when(job._client).wait_for_results(uuid.UUID(job.job_id()), job._timeout_seconds).thenReturn(client_result)
 
     with pytest.warns(UserWarning, match='Received measurement results containing zero shots.'):
         result = job.result()
@@ -225,7 +226,7 @@ def test_result_multiple_circuits(job, iqm_result_two_registers):
         measurements=[iqm_result_two_registers, iqm_result_two_registers],
         metadata=iqm_metadata_multiple_circuits,
     )
-    when(job._client).wait_for_results(uuid.UUID(job.job_id())).thenReturn(client_result)
+    when(job._client).wait_for_results(uuid.UUID(job.job_id()), job._timeout_seconds).thenReturn(client_result)
 
     result = job.result()
 
@@ -247,7 +248,7 @@ def test_result_with_timestamps(job, iqm_result_two_registers, iqm_metadata_with
         measurements=[iqm_result_two_registers],
         metadata=iqm_metadata_with_timestamps,
     )
-    when(job._client).wait_for_results(uuid.UUID(job.job_id())).thenReturn(client_result)
+    when(job._client).wait_for_results(uuid.UUID(job.job_id()), job._timeout_seconds).thenReturn(client_result)
 
     assert job.metadata.get('timestamps') is None
     result = job.result()


### PR DESCRIPTION
Added the integration of the new feature of iqm-client: Compiler option MOVE gate validation bypassing (https://github.com/iqm-finland/iqm-client/pull/124) (COMP-1468)

Added support for passing Job timeout to iqm-client: #108 (SW-381)