### PR TITLE
Preserve layout in `optimize_single_qubit_gates`.

### DIFF
--- a/src/iqm/qiskit_iqm/iqm_transpilation.py
+++ b/src/iqm/qiskit_iqm/iqm_transpilation.py
@@ -19,9 +19,9 @@ from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary
 from qiskit.circuit.library import RGate
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import BasisTranslator, Optimize1qGatesDecomposition, RemoveBarriers
 from qiskit.transpiler.passmanager import PassManager
-from qiskit.transpiler.layout import Layout
 
 
 class IQMOptimizeSingleQubitGates(TransformationPass):

--- a/src/iqm/qiskit_iqm/iqm_transpilation.py
+++ b/src/iqm/qiskit_iqm/iqm_transpilation.py
@@ -21,6 +21,7 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passes import BasisTranslator, Optimize1qGatesDecomposition, RemoveBarriers
 from qiskit.transpiler.passmanager import PassManager
+from qiskit.transpiler.layout import Layout
 
 
 class IQMOptimizeSingleQubitGates(TransformationPass):
@@ -53,6 +54,8 @@ class IQMOptimizeSingleQubitGates(TransformationPass):
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         self._validate_ops(dag)
+        layout = Layout.generate_trivial_layout(*dag.qregs.values())
+        self.property_set["layout"] = layout
         # accumulated RZ angles for each qubit, from the beginning of the circuit to the current gate
         rz_angles: list[float] = [0] * dag.num_qubits()
         if self._ignore_barriers:

--- a/src/iqm/qiskit_iqm/iqm_transpilation.py
+++ b/src/iqm/qiskit_iqm/iqm_transpilation.py
@@ -55,7 +55,7 @@ class IQMOptimizeSingleQubitGates(TransformationPass):
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         self._validate_ops(dag)
         layout = Layout.generate_trivial_layout(*dag.qregs.values())
-        self.property_set["layout"] = layout
+        self.property_set['layout'] = layout
         # accumulated RZ angles for each qubit, from the beginning of the circuit to the current gate
         rz_angles: list[float] = [0] * dag.num_qubits()
         if self._ignore_barriers:

--- a/tests/test_iqm_transpilation.py
+++ b/tests/test_iqm_transpilation.py
@@ -127,3 +127,22 @@ def test_submitted_circuit(adonis_architecture):
         'measure:2',
         'measure:4',
     ]
+
+
+def test_optimize_single_qubit_gates_preserves_layout():
+    circuit = QuantumCircuit(3)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.x(2)
+
+    transpiled_circuit = transpile(circuit, basis_gates=['r', 'cz'], initial_layout=[0, 1, 2])
+    optimized_circuit = optimize_single_qubit_gates(transpiled_circuit)
+
+    # Check if the layout is preserved
+    assert optimized_circuit.layout is not None
+    assert optimized_circuit.layout.initial_layout is not None
+
+    expected_layout = {0: 0, 1: 1, 2: 2}
+    actual_layout = {qubit.index: optimized_circuit.layout.initial_layout[qubit] for qubit in optimized_circuit.qubits}
+
+    assert actual_layout == expected_layout

--- a/tests/test_iqm_transpilation.py
+++ b/tests/test_iqm_transpilation.py
@@ -143,6 +143,6 @@ def test_optimize_single_qubit_gates_preserves_layout():
     assert optimized_circuit.layout.initial_layout is not None
 
     expected_layout = {0: 0, 1: 1, 2: 2}
-    actual_layout = {qubit.index: optimized_circuit.layout.initial_layout[qubit] for qubit in optimized_circuit.qubits}
+    actual_layout = {qubit._index: optimized_circuit.layout.initial_layout[qubit] for qubit in optimized_circuit.qubits}
 
     assert actual_layout == expected_layout


### PR DESCRIPTION
Fixes https://github.com/iqm-finland/qiskit-on-iqm/issues/118 

Currently, ancilla qubits are not added to the circuit. So the number of qubits in the quantum circuit is still reduced. 