### PR TITLE
Extract instruction serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 15.1
 ============
 
-* Expose part of instruction serialization as :func:`iqm.qiskit_iqm.iqm_provider.serialize_instructions`.
+* Move a part of circuit serialization into :func:`iqm.qiskit_iqm.iqm_provider._serialize_instructions`.
   `#126 <https://github.com/iqm-finland/qiskit-on-iqm/pull/126>`_
 
 Version 15.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 15.1
+============
+
+* Expose part of instruction serialization as :func:`iqm.qiskit_iqm.iqm_provider.serialize_instructions`.
+  `#126 <https://github.com/iqm-finland/qiskit-on-iqm/pull/126>`_
+
 Version 15.0
 ============
 

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -241,109 +241,7 @@ class IQMBackend(IQMBackendBase):
         Raises:
             ValueError: circuit contains an unsupported instruction or is not transpiled in general
         """
-        # pylint: disable=too-many-branches,too-many-statements
-        instructions: list[Instruction] = []
-        # maps clbits to the latest "measure" instruction to store its result there
-        clbit_to_measure: dict[Clbit, Instruction] = {}
-
-        for circuit_instruction in circuit.data:
-            instruction = circuit_instruction.operation
-            qubit_names = [str(circuit.find_bit(qubit).index) for qubit in circuit_instruction.qubits]
-            if instruction.name == 'r':
-                angle_t = float(instruction.params[0] / (2 * np.pi))
-                phase_t = float(instruction.params[1] / (2 * np.pi))
-                native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': angle_t, 'phase_t': phase_t})
-            elif instruction.name == 'x':
-                native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': 0.5, 'phase_t': 0.0})
-            elif instruction.name == 'rx':
-                angle_t = float(instruction.params[0] / (2 * np.pi))
-                native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': angle_t, 'phase_t': 0.0})
-            elif instruction.name == 'y':
-                native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': 0.5, 'phase_t': 0.25})
-            elif instruction.name == 'ry':
-                angle_t = float(instruction.params[0] / (2 * np.pi))
-                native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': angle_t, 'phase_t': 0.25})
-            elif instruction.name == 'cz':
-                native_inst = Instruction(name='cz', qubits=qubit_names, args={})
-            elif instruction.name == 'move':
-                native_inst = Instruction(name='move', qubits=qubit_names, args={})
-            elif instruction.name == 'barrier':
-                native_inst = Instruction(name='barrier', qubits=qubit_names, args={})
-            elif instruction.name == 'measure':
-                if len(circuit_instruction.clbits) != 1:
-                    raise ValueError(
-                        f'Unexpected: measurement instruction {circuit_instruction} uses multiple classical bits.'
-                    )
-                clbit = circuit_instruction.clbits[0]  # always a single-qubit measurement
-                mk = str(MeasurementKey.from_clbit(clbit, circuit))
-                native_inst = Instruction(name='measure', qubits=qubit_names, args={'key': mk})
-                clbit_to_measure[clbit] = native_inst
-            elif instruction.name == 'reset':
-                # implemented using a measure instruction to measure the qubits, and
-                # one cc_prx per qubit to conditionally flip it to |0>
-                feedback_key = '_reset'
-                instructions.append(
-                    Instruction(
-                        name='measure',
-                        qubits=qubit_names,
-                        args={
-                            # HACK to get something unique, remove when key can be omitted
-                            'key': f'_reset_{len(instructions)}',
-                            'feedback_key': feedback_key,
-                        },
-                    )
-                )
-                for q in qubit_names:
-                    physical_qubit_name = self._idx_to_qb[int(q)]
-                    instructions.append(
-                        Instruction(
-                            name='cc_prx',
-                            qubits=[q],
-                            args={
-                                'angle_t': 0.5,
-                                'phase_t': 0.0,
-                                'feedback_key': feedback_key,
-                                'feedback_qubit': physical_qubit_name,
-                            },
-                        )
-                    )
-                continue
-            elif instruction.name == 'id':
-                continue
-            else:
-                raise ValueError(
-                    f"Instruction '{instruction.name}' in the circuit '{circuit.name}' is not natively supported. "
-                    f'You need to transpile the circuit before execution.'
-                )
-            # classically controlled gates (using the c_if method)
-            condition = instruction.condition
-            if condition is not None:
-                if native_inst.name != 'prx':
-                    raise ValueError(
-                        'This backend only supports conditionals on r, x, y, rx and ry gates,'
-                        f' not on {instruction.name}'
-                    )
-                native_inst.name = 'cc_prx'
-                creg, value = condition
-                if len(creg) != 1:
-                    raise ValueError(f'{instruction} is conditioned on multiple bits, this is not supported.')
-                if value != 1:
-                    raise ValueError(
-                        f'{instruction} is conditioned on integer value {value}, only value 1 is supported.'
-                    )
-                # Set up feedback routing.
-                # The latest "measure" instruction to write to that classical bit is modified, it is
-                # given an explicit feedback_key equal to its measurement key.
-                # The same feedback_key is given to the controlled instruction, along with the feedback qubit.
-                measure_inst = clbit_to_measure[creg[0]]
-                feedback_key = measure_inst.args['key']
-                measure_inst.args['feedback_key'] = feedback_key  # this measure is used to provide feedback
-                # TODO we should use physical qubit names in native circuits, not integer strings
-                physical_qubit_name = self._idx_to_qb[int(measure_inst.qubits[0])]  # single-qubit measurement
-                native_inst.args['feedback_key'] = feedback_key
-                native_inst.args['feedback_qubit'] = physical_qubit_name
-
-            instructions.append(native_inst)
+        instructions = serialize_instructions(circuit, self._idx_to_qb, ignore_nonnative_gates=False)
 
         try:
             metadata = to_json_dict(circuit.metadata)
@@ -354,6 +252,137 @@ class IQMBackend(IQMBackendBase):
             metadata = None
 
         return Circuit(name=circuit.name, instructions=instructions, metadata=metadata)
+
+
+def serialize_instructions(
+    circuit: QuantumCircuit, index_to_qubit_mapping: dict[int, str], ignore_nonnative_gates: bool
+) -> list[Instruction]:
+    """Serialize a quantum circuit into Instructions in the IQM data transfer format.
+
+    This is an internal helper for :meth:`.IQMBackend.serialize_circuit` that gives slightly more control.
+    See :meth:`.IQMBackend.serialize_circuit` for details.
+    There is usually no need to use this function directly.
+
+    Args:
+        circuit: quantum circuit to serialize
+        index_to_qubit_mapping: Mapping from logical to physical qubit names.
+        ignore_nonnative_gates: If False (default), any instruction that cannot be serailizaed into the native
+            gate set will raise an error. If True, such instructions are converted as-is without validation,
+            and the caller must edit the result to be valid and executable.
+            Notably, since IQM transfer format requires named parameters and qiskit parameters don't have names, the
+            `i` th parameter of an unrecognized instruction is given the name ``"param<i>"``.
+
+    Returns:
+        list of instructions representing the circuit
+
+    Raises:
+        ValueError: circuit contains an unsupported instruction or is not transpiled in general
+    """
+    # pylint: disable=too-many-branches,too-many-statements
+    instructions: list[Instruction] = []
+    # maps clbits to the latest "measure" instruction to store its result there
+    clbit_to_measure: dict[Clbit, Instruction] = {}
+    for circuit_instruction in circuit.data:
+        instruction = circuit_instruction.operation
+        qubit_names = [str(circuit.find_bit(qubit).index) for qubit in circuit_instruction.qubits]
+        if instruction.name == 'r':
+            angle_t = float(instruction.params[0] / (2 * np.pi))
+            phase_t = float(instruction.params[1] / (2 * np.pi))
+            native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': angle_t, 'phase_t': phase_t})
+        elif instruction.name == 'x':
+            native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': 0.5, 'phase_t': 0.0})
+        elif instruction.name == 'rx':
+            angle_t = float(instruction.params[0] / (2 * np.pi))
+            native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': angle_t, 'phase_t': 0.0})
+        elif instruction.name == 'y':
+            native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': 0.5, 'phase_t': 0.25})
+        elif instruction.name == 'ry':
+            angle_t = float(instruction.params[0] / (2 * np.pi))
+            native_inst = Instruction(name='prx', qubits=qubit_names, args={'angle_t': angle_t, 'phase_t': 0.25})
+        elif instruction.name == 'cz':
+            native_inst = Instruction(name='cz', qubits=qubit_names, args={})
+        elif instruction.name == 'move':
+            native_inst = Instruction(name='move', qubits=qubit_names, args={})
+        elif instruction.name == 'barrier':
+            native_inst = Instruction(name='barrier', qubits=qubit_names, args={})
+        elif instruction.name == 'measure':
+            if len(circuit_instruction.clbits) != 1:
+                raise ValueError(
+                    f'Unexpected: measurement instruction {circuit_instruction} uses multiple classical bits.'
+                )
+            clbit = circuit_instruction.clbits[0]  # always a single-qubit measurement
+            mk = str(MeasurementKey.from_clbit(clbit, circuit))
+            native_inst = Instruction(name='measure', qubits=qubit_names, args={'key': mk})
+            clbit_to_measure[clbit] = native_inst
+        elif instruction.name == 'reset':
+            # implemented using a measure instruction to measure the qubits, and
+            # one cc_prx per qubit to conditionally flip it to |0>
+            feedback_key = '_reset'
+            instructions.append(
+                Instruction(
+                    name='measure',
+                    qubits=qubit_names,
+                    args={
+                        # HACK to get something unique, remove when key can be omitted
+                        'key': f'_reset_{len(instructions)}',
+                        'feedback_key': feedback_key,
+                    },
+                )
+            )
+            for q in qubit_names:
+                physical_qubit_name = index_to_qubit_mapping[int(q)]
+                instructions.append(
+                    Instruction(
+                        name='cc_prx',
+                        qubits=[q],
+                        args={
+                            'angle_t': 0.5,
+                            'phase_t': 0.0,
+                            'feedback_key': feedback_key,
+                            'feedback_qubit': physical_qubit_name,
+                        },
+                    )
+                )
+            continue
+        elif instruction.name == 'id':
+            continue
+        else:
+            if ignore_nonnative_gates:
+                args = {f"param{i}": param for i, param in enumerate(instruction.params)}
+                native_inst = Instruction.construct(name=instruction.name, qubits=qubit_names, args=args)
+            else:
+                raise ValueError(
+                    f"Instruction '{instruction.name}' in the circuit '{circuit.name}' is not natively supported. "
+                    f'You need to transpile the circuit before execution.'
+                )
+
+        # classically controlled gates (using the c_if method)
+        condition = instruction.condition
+        if condition is not None:
+            if native_inst.name != 'prx':
+                raise ValueError(
+                    'This backend only supports conditionals on r, x, y, rx and ry gates,' f' not on {instruction.name}'
+                )
+            native_inst.name = 'cc_prx'
+            creg, value = condition
+            if len(creg) != 1:
+                raise ValueError(f'{instruction} is conditioned on multiple bits, this is not supported.')
+            if value != 1:
+                raise ValueError(f'{instruction} is conditioned on integer value {value}, only value 1 is supported.')
+            # Set up feedback routing.
+            # The latest "measure" instruction to write to that classical bit is modified, it is
+            # given an explicit feedback_key equal to its measurement key.
+            # The same feedback_key is given to the controlled instruction, along with the feedback qubit.
+            measure_inst = clbit_to_measure[creg[0]]
+            feedback_key = measure_inst.args['key']
+            measure_inst.args['feedback_key'] = feedback_key  # this measure is used to provide feedback
+            # TODO we should use physical qubit names in native circuits, not integer strings
+            physical_qubit_name = index_to_qubit_mapping[int(measure_inst.qubits[0])]  # single-qubit measurement
+            native_inst.args['feedback_key'] = feedback_key
+            native_inst.args['feedback_qubit'] = physical_qubit_name
+
+        instructions.append(native_inst)
+    return instructions
 
 
 class IQMFacadeBackend(IQMBackend):

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -348,7 +348,7 @@ def _serialize_instructions(
         else:
             if instruction.name in allowed_nonnative_gates:
                 args = {f'p{i}': param for i, param in enumerate(instruction.params)}
-                native_inst = Instruction.model_construct(name=instruction.name, qubits=qubit_names, args=args)
+                native_inst = Instruction.model_construct(name=instruction.name, qubits=tuple(qubit_names), args=args)
             else:
                 raise ValueError(
                     f"Instruction '{instruction.name}' in the circuit '{circuit.name}' is not natively supported. "

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -255,7 +255,7 @@ class IQMBackend(IQMBackendBase):
 
 
 def _serialize_instructions(
-    circuit: QuantumCircuit, index_to_qubit_mapping: dict[int, str], allowed_nonnative_gates: Collection[str] = ()
+    circuit: QuantumCircuit, qubit_index_to_name: dict[int, str], allowed_nonnative_gates: Collection[str] = ()
 ) -> list[Instruction]:
     """Serialize a quantum circuit into the IQM data transfer format.
 
@@ -264,7 +264,7 @@ def _serialize_instructions(
 
     Args:
         circuit: quantum circuit to serialize
-        index_to_qubit_mapping: Mapping from qubit indices to the corresponding qubit names.
+        qubit_index_to_name: Mapping from qubit indices to the corresponding qubit names.
         allowed_nonnative_gates: Names of gates that are converted as-is without validation.
             By default, any gate that can't be converted will raise an error.
             If such gates are present in the circuit, the caller must edit the result to be valid and executable.
@@ -329,7 +329,7 @@ def _serialize_instructions(
                 )
             )
             for q in qubit_names:
-                physical_qubit_name = index_to_qubit_mapping[int(q)]
+                physical_qubit_name = qubit_index_to_name[int(q)]
                 instructions.append(
                     Instruction(
                         name='cc_prx',
@@ -375,7 +375,7 @@ def _serialize_instructions(
             feedback_key = measure_inst.args['key']
             measure_inst.args['feedback_key'] = feedback_key  # this measure is used to provide feedback
             # TODO we should use physical qubit names in native circuits, not integer strings
-            physical_qubit_name = index_to_qubit_mapping[int(measure_inst.qubits[0])]  # single-qubit measurement
+            physical_qubit_name = qubit_index_to_name[int(measure_inst.qubits[0])]  # single-qubit measurement
             native_inst.args['feedback_key'] = feedback_key
             native_inst.args['feedback_qubit'] = physical_qubit_name
 

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -270,7 +270,7 @@ def serialize_instructions(
             gate set will raise an error. If True, such instructions are converted as-is without validation,
             and the caller must edit the result to be valid and executable.
             Notably, since IQM transfer format requires named parameters and qiskit parameters don't have names, the
-            `i` th parameter of an unrecognized instruction is given the name ``"param<i>"``.
+            `i` th parameter of an unrecognized instruction is given the name ``"p<i>"``.
 
     Returns:
         list of instructions representing the circuit
@@ -348,7 +348,7 @@ def serialize_instructions(
             continue
         else:
             if ignore_nonnative_gates:
-                args = {f"param{i}": param for i, param in enumerate(instruction.params)}
+                args = {f"p{i}": param for i, param in enumerate(instruction.params)}
                 native_inst = Instruction.construct(name=instruction.name, qubits=qubit_names, args=args)
             else:
                 raise ValueError(

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -345,15 +345,14 @@ def _serialize_instructions(
             continue
         elif instruction.name == 'id':
             continue
+        elif instruction.name in allowed_nonnative_gates:
+            args = {f'p{i}': param for i, param in enumerate(instruction.params)}
+            native_inst = Instruction.model_construct(name=instruction.name, qubits=tuple(qubit_names), args=args)
         else:
-            if instruction.name in allowed_nonnative_gates:
-                args = {f'p{i}': param for i, param in enumerate(instruction.params)}
-                native_inst = Instruction.model_construct(name=instruction.name, qubits=tuple(qubit_names), args=args)
-            else:
-                raise ValueError(
-                    f"Instruction '{instruction.name}' in the circuit '{circuit.name}' is not natively supported. "
-                    f'You need to transpile the circuit before execution.'
-                )
+            raise ValueError(
+                f"Instruction '{instruction.name}' in the circuit '{circuit.name}' is not natively supported. "
+                f'You need to transpile the circuit before execution.'
+            )
 
         # classically controlled gates (using the c_if method)
         condition = instruction.condition

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -257,7 +257,7 @@ class IQMBackend(IQMBackendBase):
 def serialize_instructions(
     circuit: QuantumCircuit, index_to_qubit_mapping: dict[int, str], ignore_nonnative_gates: bool
 ) -> list[Instruction]:
-    """Serialize a quantum circuit into Instructions in the IQM data transfer format.
+    """Serialize a quantum circuit into the IQM data transfer format.
 
     This is an internal helper for :meth:`.IQMBackend.serialize_circuit` that gives slightly more control.
     See :meth:`.IQMBackend.serialize_circuit` for details.
@@ -265,7 +265,7 @@ def serialize_instructions(
 
     Args:
         circuit: quantum circuit to serialize
-        index_to_qubit_mapping: Mapping from logical to physical qubit names.
+        qubit_idx_to_name: Mapping from qubit indices to the corresponding qubit names.
         ignore_nonnative_gates: If False (default), any instruction that cannot be serailizaed into the native
             gate set will raise an error. If True, such instructions are converted as-is without validation,
             and the caller must edit the result to be valid and executable.

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -348,8 +348,8 @@ def serialize_instructions(
             continue
         else:
             if ignore_nonnative_gates:
-                args = {f"p{i}": param for i, param in enumerate(instruction.params)}
-                native_inst = Instruction.construct(name=instruction.name, qubits=qubit_names, args=args)
+                args = {f'p{i}': param for i, param in enumerate(instruction.params)}
+                native_inst = Instruction.model_construct(name=instruction.name, qubits=qubit_names, args=args)
             else:
                 raise ValueError(
                     f"Instruction '{instruction.name}' in the circuit '{circuit.name}' is not natively supported. "

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -134,4 +134,4 @@ def test_serialize_instructions_can_allow_nonnative_gates():
     instructions = _serialize_instructions(
         circuit, {i: f'QB{i+1}' for i in range(5)}, allowed_nonnative_gates={'nonnative'}
     )
-    assert instructions[0] == Instruction.model_construct(name='nonnative', qubits=['1', '2', '4'], args={})
+    assert instructions[0] == Instruction.model_construct(name='nonnative', qubits=('1', '2', '4'), args={})

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -23,7 +23,7 @@ from qiskit import QuantumCircuit
 import requests
 
 from iqm.iqm_client import Instruction, IQMClient, RunRequest, RunResult, RunStatus
-from iqm.qiskit_iqm.iqm_provider import IQMBackend, IQMFacadeBackend, IQMProvider, serialize_instructions
+from iqm.qiskit_iqm.iqm_provider import IQMBackend, IQMFacadeBackend, IQMProvider, _serialize_instructions
 from tests.utils import get_mock_ok_response
 
 
@@ -129,7 +129,9 @@ def test_serialize_instructions_can_allow_nonnative_gates():
     circuit.measure_all()
 
     with pytest.raises(ValueError, match='is not natively supported. You need to transpile'):
-        serialize_instructions(circuit, {i: f'QB{i+1}' for i in range(5)}, ignore_nonnative_gates=False)
+        _serialize_instructions(circuit, {i: f'QB{i+1}' for i in range(5)})
 
-    instructions = serialize_instructions(circuit, {i: f'QB{i+1}' for i in range(5)}, ignore_nonnative_gates=True)
+    instructions = _serialize_instructions(
+        circuit, {i: f'QB{i+1}' for i in range(5)}, allowed_nonnative_gates={'nonnative'}
+    )
     assert instructions[0] == Instruction.model_construct(name='nonnative', qubits=['1', '2', '4'], args={})

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -127,11 +127,10 @@ def test_serialize_instructions_can_allow_nonnative_gates():
     circuit = QuantumCircuit(5)
     circuit.append(nonnative_gate, [1, 2, 4])
     circuit.measure_all()
+    mapping = {i: f'QB{i + 1}' for i in range(5)}
 
     with pytest.raises(ValueError, match='is not natively supported. You need to transpile'):
-        _serialize_instructions(circuit, {i: f'QB{i+1}' for i in range(5)})
+        _serialize_instructions(circuit, mapping)
 
-    instructions = _serialize_instructions(
-        circuit, {i: f'QB{i+1}' for i in range(5)}, allowed_nonnative_gates={'nonnative'}
-    )
+    instructions = _serialize_instructions(circuit, mapping, allowed_nonnative_gates={'nonnative'})
     assert instructions[0] == Instruction.model_construct(name='nonnative', qubits=('1', '2', '4'), args={})

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -132,4 +132,4 @@ def test_serialize_instructions_can_allow_nonnative_gates():
         serialize_instructions(circuit, {i: f'QB{i+1}' for i in range(5)}, ignore_nonnative_gates=False)
 
     instructions = serialize_instructions(circuit, {i: f'QB{i+1}' for i in range(5)}, ignore_nonnative_gates=True)
-    assert instructions[0] == Instruction.construct(name='nonnative', qubits=['1', '2', '4'], args={})
+    assert instructions[0] == Instruction.model_construct(name='nonnative', qubits=['1', '2', '4'], args={})


### PR DESCRIPTION
- Extract most of the instruction conversion logic from a backend method to a pure function. The old behavior is not changed but  GitHub does not show the changes neatly.