### PR TITLE
Do not use original request directly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,17 +2,20 @@
 Changelog
 =========
 
+Version 15.5
+============
+
+* Fix compatibility with ``iqm-client`` V2 APIVariant. `#132 <https://github.com/iqm-finland/qiskit-on-iqm/pull/132>`_
+
 Version 15.4
 ============
 
 * Update user guide to incorporate IQM Resonance. `#129 <https://github.com/iqm-finland/qiskit-on-iqm/pull/129>`_
 
-
 Version 15.3
 ============
 
 * Multiplexed measurements explained in the user guide. `#130 <https://github.com/iqm-finland/qiskit-on-iqm/pull/130>`_
-
 
 Version 15.2
 ============

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -34,9 +34,9 @@ IQM Resonance
 4. Install Qiskit on IQM as instructed below.
 5. Add your API token to the example (either as the parameter ``token`` to the :class:`.IQMProvider`
    constructor, or by setting the environment variable :envvar:`IQM_TOKEN`)
-5. Run the Jupyter notebook (or run ``python resonance_example.py`` if you decided to go for the Python script).
-6. If you're connecting to a real quantum computer, the output should show almost half of the
-   measurements resulting in '00000' and almost half in '11111' – if this is the case, things are
+6. Run the Jupyter notebook (or run ``python resonance_example.py`` if you decided to go for the Python script).
+7. If you're connecting to a real quantum computer, the output should show almost half of the
+   measurements resulting in '00000' and almost half in '11111' - if this is the case, things are
    set up correctly!
 
 You can find a video guide on how to set things up `here <https://www.iqmacademy.com/tutorials/resonance/>`.
@@ -51,9 +51,9 @@ On-premises device
 3. Install Cortex CLI and log in as instructed in the
    `documentation <https://iqm-finland.github.io/cortex-cli/readme.html#installing-cortex-cli>`__
 4. Set the environment variable as instructed by Cortex CLI after logging in.
-5. Run ``$ python bell_measure.py --cortex_server_url https://demo.qc.iqm.fi/cocos`` – replace the example URL with the correct one.
+5. Run ``$ python bell_measure.py --cortex_server_url https://demo.qc.iqm.fi/cocos`` - replace the example URL with the correct one.
 6. If you're connecting to a real quantum computer, the output should show almost half of the
-   measurements resulting in '00' and almost half in '11' – if this is the case, things are set up
+   measurements resulting in '00' and almost half in '11' - if this is the case, things are set up
    correctly!
 
 

--- a/src/iqm/qiskit_iqm/iqm_job.py
+++ b/src/iqm/qiskit_iqm/iqm_job.py
@@ -75,11 +75,7 @@ class IQMJob(JobV1):
             raise ValueError(
                 f'Cannot format IQM result without measurements. Job status is "{iqm_result.status.value.upper()}"'
             )
-        if iqm_result.metadata.request is None:
-            raise ValueError(
-                f'Cannot format IQM result without original request. Job status is "{iqm_result.status.value.upper()}"'
-            )
-        requested_shots = self.metadata.get('shots', iqm_result.metadata.request.shots)
+        requested_shots = self.metadata.get('shots', iqm_result.metadata.shots)
         # If no heralding, for all circuits we expect the same number of shots which is the shots requested by user.
         expect_exact_shots = iqm_result.metadata.heralding_mode == HeraldingMode.NONE
 

--- a/tests/test_iqm_backend.py
+++ b/tests/test_iqm_backend.py
@@ -18,12 +18,13 @@ from collections.abc import Sequence
 import re
 import uuid
 
-from mockito import ANY, expect, mock, unstub, verifyNoUnwantedInteractions, when
+from mockito import ANY, expect, matchers, mock, unstub, verifyNoUnwantedInteractions, when
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit import ClassicalRegister, Parameter, QuantumRegister
 from qiskit.circuit.library import CZGate, RGate, RXGate, RYGate, XGate, YGate
+import requests
 
 from iqm.iqm_client import (
     APIConfig,
@@ -35,6 +36,7 @@ from iqm.iqm_client import (
     RunRequest,
 )
 from iqm.qiskit_iqm.iqm_provider import IQMBackend, IQMJob
+from tests.utils import get_mock_ok_response
 
 
 @pytest.fixture
@@ -113,12 +115,16 @@ def test_set_max_circuits(backend):
 
 
 def test_serialize_circuit_raises_error_for_non_transpiled_circuit(circuit, linear_3q_architecture):
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
     client = IQMClient(url='http://some_url')
     client._token_manager = None  # Do not use authentication
     when(client).get_dynamic_quantum_architecture(None).thenReturn(linear_3q_architecture)
     when(client).get_dynamic_quantum_architecture(linear_3q_architecture.calibration_set_id).thenReturn(
         linear_3q_architecture
     )
+
     backend = IQMBackend(client)
     circuit = QuantumCircuit(3)
     circuit.cz(0, 2)

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -45,6 +45,9 @@ def run_request():
 def test_get_backend(linear_3q_architecture):
     url = 'http://some_url'
     when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(linear_3q_architecture)
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
 
     provider = IQMProvider(url)
     backend = provider.get_backend()
@@ -59,6 +62,9 @@ def test_get_backend(linear_3q_architecture):
 def test_client_signature(adonis_architecture):
     url = 'http://some_url'
     provider = IQMProvider(url)
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
     when(requests).get(
         'http://some_url/api/v1/calibration/default/gates', headers=matchers.ANY, timeout=matchers.ANY
     ).thenReturn(get_mock_ok_response(adonis_architecture.model_dump()))
@@ -69,6 +75,9 @@ def test_client_signature(adonis_architecture):
 def test_get_facade_backend(adonis_architecture, adonis_coupling_map):
     url = 'http://some_url'
     when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
 
     provider = IQMProvider(url)
     backend = provider.get_backend('facade_adonis')
@@ -83,6 +92,9 @@ def test_get_facade_backend_raises_error_non_matching_architecture(linear_3q_arc
     url = 'http://some_url'
 
     when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(linear_3q_architecture)
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
 
     provider = IQMProvider(url)
     with pytest.raises(ValueError, match='Quantum architecture of the remote quantum computer does not match Adonis.'):
@@ -113,6 +125,9 @@ def test_facade_backend_raises_error_on_remote_execution_fail(adonis_architectur
     when(IQMClient).submit_run_request(...).thenReturn(uuid.uuid4())
     when(IQMClient).get_run(ANY(uuid.UUID)).thenReturn(RunResult.from_dict(result))
     when(IQMClient).get_run_status(ANY(uuid.UUID)).thenReturn(RunStatus.from_dict(result_status))
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
 
     provider = IQMProvider(url)
     backend = provider.get_backend('facade_adonis')

--- a/tests/test_resonance_example.py
+++ b/tests/test_resonance_example.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Qiskit on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Testing Resonance example script.
+"""
+
+
+import subprocess
+import sys
+
+from iqm.qiskit_iqm.examples import resonance_example
+
+
+def test_resonance_example_call():
+    """Test that example script runs and fails at establishing a connection."""
+    with subprocess.Popen(
+        (sys.executable, resonance_example.__file__, "--url", "https://not.a.real.domain", "--token", "fake_token"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ) as p:
+        (_, err) = p.communicate()
+        p.wait()
+        assert "ConnectionError" in str(err)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,7 +43,10 @@ ALLOWED_OP_NAMES = get_type_hints(AllowedOps).keys()
 
 def get_mocked_backend(architecture: DynamicQuantumArchitecture) -> tuple[IQMBackend, IQMClient]:
     """Returns an IQM backend running on a mocked IQM client that returns the given architecture."""
-    client = IQMClient(url='http://localhost')
+    when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
+        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+    )
+    client = IQMClient(url='http://some_url')
     when(client).get_dynamic_quantum_architecture(None).thenReturn(architecture)
     when(client).get_dynamic_quantum_architecture(architecture.calibration_set_id).thenReturn(architecture)
     backend = IQMBackend(client)


### PR DESCRIPTION
- This fixes compatibility with iqm-client APIVariant V2.
- support iqm-client 20.5 in unit tests
- make resonance example testable, an improvement over @manzanillo implementation from https://github.com/iqm-finland/qiskit-on-iqm/pull/131
- cherry-pick resonance guide by @freetonik from https://github.com/iqm-finland/qiskit-on-iqm/pull/131

I suggest also closing https://github.com/iqm-finland/qiskit-on-iqm/pull/131 if this one is merged.