### PR TITLE
Reflect Resonance authentication in docs better

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -79,7 +79,7 @@ Authentication
 --------------
 
 IQM Server (on-premise devices)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===============================
 If the IQM server you are connecting to requires authentication, you may use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,
 then set the :envvar:`IQM_TOKENS_FILE` environment variable, as instructed, to point to the tokens file.
@@ -91,7 +91,7 @@ arguments to :class:`.IQMProvider`, however this approach is less secure and con
 
 
 IQM Resonance
-^^^^^^^^^^^^^
+=============
 If you are using ``IQM Resonance``, you have two options to authenticate:
 
 1. Set the :envvar:`IQM_TOKEN` environment variable with the API token obtained from the server dashboard.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -78,6 +78,8 @@ After installation Qiskit on IQM can be imported in your Python code as follows:
 Authentication
 --------------
 
+IQM Server (on-premise devices)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If the IQM server you are connecting to requires authentication, you may use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,
 then set the :envvar:`IQM_TOKENS_FILE` environment variable, as instructed, to point to the tokens file.
@@ -87,9 +89,15 @@ You may also authenticate yourself using the :envvar:`IQM_AUTH_SERVER`,
 :envvar:`IQM_AUTH_USERNAME` and :envvar:`IQM_AUTH_PASSWORD` environment variables, or pass them as
 arguments to :class:`.IQMProvider`, however this approach is less secure and considered deprecated.
 
-Finally, if you are using ``IQM Resonance``, authentication is handled differently.
-Use the :envvar:`IQM_TOKEN` environment variable to provide the API Token obtained
-from the server dashboard.
+
+IQM Resonance
+^^^^^^^^^^^^^
+If you are using ``IQM Resonance``, you have two options to authenticate:
+
+1. Set the :envvar:`IQM_TOKEN` environment variable with the API token obtained from the server dashboard.
+2. Pass the `token` parameter to :class:`.IQMProvider`. This will be forwarded to `IQM Client <https://iqm-finland.github.io/docs/iqm-client/>`_. 
+   For an example, see `resonance_example.py example file <https://raw.githubusercontent.com/iqm-finland/qiskit-on-iqm/main/src/iqm/qiskit_iqm/examples/resonance_example.py>`_
+
 
 
 Running quantum circuits on an IQM quantum computer

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -22,13 +22,13 @@ through the IQM cloud service Resonance, or using an on-premises quantum compute
 IQM Resonance
 ~~~~~~~~~~~~~
 
-1. Login to `IQM Resonance <https://resonance.meetiqm.com>` with your credentials.
+1. Login to `IQM Resonance <https://resonance.meetiqm.com>`_ with your credentials.
 2. Upon your first visit to IQM Resonance, you can generate your unique, non-recoverable API token
    directly from the Dashboard page by selecting ``Generate token``. It's important to copy the token
    immediately from the window, as you won't be able to do so once the window is closed. If you lose
    your token, you have the option to regenerate it at any time. However, be aware that regenerating
    your API token will invalidate any previously generated token.
-3. Download one of the demo notebooks from `IQM Academy <https://www.iqmacademy.com/tutorials/>` or the
+3. Download one of the demo notebooks from `IQM Academy <https://www.iqmacademy.com/tutorials/>`_ or the
    `resonance_example.py example file <https://raw.githubusercontent.com/iqm-finland/qiskit-on-iqm/main/src/iqm/qiskit_iqm/examples/resonance_example.py>`_
    (Save Page As...)
 4. Install Qiskit on IQM as instructed below.
@@ -39,8 +39,8 @@ IQM Resonance
    measurements resulting in '00000' and almost half in '11111' - if this is the case, things are
    set up correctly!
 
-You can find a video guide on how to set things up `here <https://www.iqmacademy.com/tutorials/resonance/>`.
-More ready-to-run examples can also be found at `IQM Academy <https://www.iqmacademy.com/tutorials/>`.
+You can find a video guide on how to set things up `here <https://www.iqmacademy.com/tutorials/resonance/>`_.
+More ready-to-run examples can also be found at `IQM Academy <https://www.iqmacademy.com/tutorials/>`_.
 
 
 On-premises device
@@ -78,8 +78,19 @@ After installation Qiskit on IQM can be imported in your Python code as follows:
 Authentication
 --------------
 
-IQM Server (on-premise devices)
-===============================
+IQM Resonance
+~~~~~~~~~~~~~
+
+If you are using IQM Resonance, you have two options to authenticate:
+
+1. Set the :envvar:`IQM_TOKEN` environment variable to the API token obtained from the Resonance dashboard.
+2. Pass the ``token`` parameter to :class:`.IQMProvider`. This will be forwarded to
+   :class:`~iqm.iqm_client.iqm_client.IQMClient`. For an example, see the `resonance_example.py file
+   <https://raw.githubusercontent.com/iqm-finland/qiskit-on-iqm/main/src/iqm/qiskit_iqm/examples/resonance_example.py>`_
+
+On-premises devices
+~~~~~~~~~~~~~~~~~~~
+
 If the IQM server you are connecting to requires authentication, you may use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,
 then set the :envvar:`IQM_TOKENS_FILE` environment variable, as instructed, to point to the tokens file.
@@ -88,16 +99,6 @@ See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme
 You may also authenticate yourself using the :envvar:`IQM_AUTH_SERVER`,
 :envvar:`IQM_AUTH_USERNAME` and :envvar:`IQM_AUTH_PASSWORD` environment variables, or pass them as
 arguments to :class:`.IQMProvider`, however this approach is less secure and considered deprecated.
-
-
-IQM Resonance
-=============
-If you are using ``IQM Resonance``, you have two options to authenticate:
-
-1. Set the :envvar:`IQM_TOKEN` environment variable with the API token obtained from the server dashboard.
-2. Pass the `token` parameter to :class:`.IQMProvider`. This will be forwarded to `IQM Client <https://iqm-finland.github.io/docs/iqm-client/>`_. 
-   For an example, see `resonance_example.py example file <https://raw.githubusercontent.com/iqm-finland/qiskit-on-iqm/main/src/iqm/qiskit_iqm/examples/resonance_example.py>`_
-
 
 
 Running quantum circuits on an IQM quantum computer

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -433,20 +433,13 @@ class IQMFacadeBackend(IQMBackend):
 class IQMProvider:
     """Provider for IQM backends.
 
-    Args:
-        url: URL of the IQM Quantum Computer (e.g. https://cocos.resonance.meetiqm.com/garnet)
+    IQMProvider connects to a quantum computer through an IQM server.
+    If the server requires user authentication, you can provide it either using environment
+    variables, or as keyword arguments to IQMProvider. The user authentication kwargs are passed
+    through to :class:`~iqm.iqm_client.iqm_client.IQMClient` as is, and are documented there.
 
-    Keyword Args:
-        auth_server_url: URL of the user authentication server, if required by the IQM Cortex server, not required for IQM Resonance.
-            Can also be set in the ``IQM_AUTH_SERVER`` environment variable.
-        username: Username, if required by the IQM Cortex server, not required for IQM Resonance.
-            Can also be set in the ``IQM_AUTH_USERNAME`` environment variable.
-        password: Password, if required by the IQM Cortex server, not required for IQM Resonance.
-            Can also be set in the ``IQM_AUTH_PASSWORD`` environment variable.
-        password: Password, if required by the IQM Cortex server, not required for IQM Resonance.
-            Can also be set in the ``IQM_AUTH_PASSWORD`` environment variable.
-        token: API token retrieved from IQM Resonance, not required for on-premise quantum computers.
-            Can also be set in the ``IQM_TOKEN`` environment variable.
+    Args:
+        url: URL of the IQM server (e.g. https://cocos.resonance.meetiqm.com/garnet)
     """
 
     def __init__(self, url: str, **user_auth_args):  # contains keyword args auth_server_url, username, password

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -437,7 +437,7 @@ class IQMProvider:
         url: URL of the IQM Quantum Computer (e.g. https://cocos.resonance.meetiqm.com/garnet)
 
     Keyword Args:
-        auth_server_url: URL of the user authentication server, if required by the IQM Cortex server.
+        auth_server_url: URL of the user authentication server, if required by the IQM Cortex server, not required for IQM Resonance.
             Can also be set in the ``IQM_AUTH_SERVER`` environment variable.
         username: Username, if required by the IQM Cortex server, not required for IQM Resonance.
             Can also be set in the ``IQM_AUTH_USERNAME`` environment variable.

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -434,15 +434,19 @@ class IQMProvider:
     """Provider for IQM backends.
 
     Args:
-        url: URL of the IQM Cortex server
+        url: URL of the IQM Quantum Computer (e.g. https://cocos.resonance.meetiqm.com/garnet)
 
     Keyword Args:
         auth_server_url: URL of the user authentication server, if required by the IQM Cortex server.
             Can also be set in the ``IQM_AUTH_SERVER`` environment variable.
-        username: Username, if required by the IQM Cortex server.
+        username: Username, if required by the IQM Cortex server, not required for IQM Resonance.
             Can also be set in the ``IQM_AUTH_USERNAME`` environment variable.
-        password: Password, if required by the IQM Cortex server.
+        password: Password, if required by the IQM Cortex server, not required for IQM Resonance.
             Can also be set in the ``IQM_AUTH_PASSWORD`` environment variable.
+        password: Password, if required by the IQM Cortex server, not required for IQM Resonance.
+            Can also be set in the ``IQM_AUTH_PASSWORD`` environment variable.
+        token: API token retrieved from IQM Resonance, not required for on-premise quantum computers.
+            Can also be set in the ``IQM_TOKEN`` environment variable.
     """
 
     def __init__(self, url: str, **user_auth_args):  # contains keyword args auth_server_url, username, password


### PR DESCRIPTION
This pull request updates the authentication process in `IQMProvider` and improves the user guide to better reflect the usage of IQM Resonance.

Changes:
* Updated IQMProvider to mention authentication option for IQM Resonance 
* Mentioned the support for the token parameter in the User guide.
* Added separating headlines for IQM Resonance and on-prem QCs
