### PR TITLE
SW-803: Bugfix in IQMOptimizeSingleQubitGates where the angles are not properly computed 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+
+Version 17.1
+============
+
+* Bugfix in :class:`IQMOptimizeSingleQubitGates`` where the angles are not properly computed for circuits 
+  with prx gates on qubits holding a resonator state, i.e. circuits that require running without move gate validation.
+
+
 Version 17.0
 ============
 

--- a/src/iqm/qiskit_iqm/iqm_transpilation.py
+++ b/src/iqm/qiskit_iqm/iqm_transpilation.py
@@ -58,7 +58,6 @@ class IQMOptimizeSingleQubitGates(TransformationPass):
         self._ignore_barriers = ignore_barriers
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
-        print("Start")
         self._validate_ops(dag)
         # accumulated RZ angles for each qubit, from the beginning of the circuit to the current gate
         rz_angles: list[float] = [0] * dag.num_qubits()
@@ -73,7 +72,6 @@ class IQMOptimizeSingleQubitGates(TransformationPass):
             if node.name == 'u':
                 qubit_index = dag.find_bit(node.qargs[0])[0]
                 if math.isclose(node.op.params[0], 0, abs_tol=TOLERANCE):
-                    print("removing node")
                     dag.remove_op_node(node)
                 else:
                     dag.substitute_node(

--- a/tests/fake_backends/test_fake_deneb.py
+++ b/tests/fake_backends/test_fake_deneb.py
@@ -204,18 +204,21 @@ def test_qiskit_transpile_for_ghz_with_fake_deneb_noise_model():
 
 def test_transpiling_works_but_backend_run_doesnt_with_unsupported_gates():
     backend = IQMFakeDeneb()
-    num_qb = 6
+    num_qb = 1
     qc_list = []
     for _ in range(4):
         qc_list.append(QuantumCircuit(num_qb))
 
-    qc_list[0].h(1)
-    qc_list[1].sdg(2)
-    qc_list[2].t(3)
-    qc_list[3].s(4)
+    qc_list[0].h(0)
+    qc_list[1].sdg(0)
+    qc_list[2].t(0)
+    qc_list[3].s(0)
+
+    for i in range(4):
+        qc_list[i].measure_all()
 
     for qc in qc_list:
-        backend.run(transpile(qc, backend=backend), shots=1000)
+        backend.run(transpile_to_IQM(qc, backend=backend), shots=1000)
 
         with pytest.raises(
             ValueError,

--- a/tests/test_iqm_transpilation.py
+++ b/tests/test_iqm_transpilation.py
@@ -15,16 +15,21 @@
 """
 
 import numpy as np
+import math
 import pytest
 from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary
 from qiskit_aer import AerSimulator
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes import BasisTranslator
 
 from iqm.qiskit_iqm.fake_backends.fake_adonis import IQMFakeAdonis
 from iqm.qiskit_iqm.fake_backends.fake_aphrodite import IQMFakeAphrodite
 from iqm.qiskit_iqm.fake_backends.fake_deneb import IQMFakeDeneb
 from iqm.qiskit_iqm.iqm_circuit_validation import validate_circuit
 from iqm.qiskit_iqm.iqm_move_layout import generate_initial_layout
-from iqm.qiskit_iqm.iqm_transpilation import optimize_single_qubit_gates
+from iqm.qiskit_iqm.iqm_transpilation import optimize_single_qubit_gates, IQMOptimizeSingleQubitGates, TOLERANCE
+from iqm.qiskit_iqm.move_gate import MoveGate
 from tests.utils import get_mocked_backend
 
 
@@ -150,3 +155,22 @@ def test_qiskit_native_transpiler(move_architecture, optimization_level):
     qc.measure_all()
     transpiled_circuit = transpile(qc, backend=backend, optimization_level=optimization_level)
     validate_circuit(transpiled_circuit, backend)
+
+def test_optimize_single_qubit_gates_works_on_invalid_move_sandwich():
+    """Tests that the optimization pass works on a circuit with an invalid MOVE sandwich.
+    In case the user is wanting to use the higher energy levels but also optimize the SQGs in the circuit."""
+    qc = QuantumCircuit(2)
+    qc.rz(0.5, 1)
+    qc.append(MoveGate(), [1, 0])
+    qc.x(1)
+    qc.append(MoveGate(), [1, 0])
+    basis_circuit =  PassManager([BasisTranslator(SessionEquivalenceLibrary, ['r', 'cz', 'move'])]).run(qc)
+    transpiled_circuit =  PassManager([BasisTranslator(SessionEquivalenceLibrary, ['r', 'cz', 'move']), IQMOptimizeSingleQubitGates(True, True)]).run(basis_circuit)
+    assert transpiled_circuit.count_ops()['r'] == 1
+    assert transpiled_circuit.count_ops()['move'] == 2
+    for gate in transpiled_circuit:
+        if gate.operation.name == 'r':
+            assert math.isclose(gate.operation.params[0], np.pi, rel_tol=TOLERANCE)
+            assert math.isclose(gate.operation.params[1], 0, abs_tol=TOLERANCE)
+
+


### PR DESCRIPTION
Bugfix in ``IQMOptimizeSingleQubitGates`` where the angles are not properly computed for circuits with prx gates on qubits holding a resonator state, i.e. circuits that require running without move gate validation.

