### PR TITLE
add warning when unknown facade name is used

### DIFF
--- a/src/iqm/qiskit_iqm/iqm_naive_move_pass.py
+++ b/src/iqm/qiskit_iqm/iqm_naive_move_pass.py
@@ -192,7 +192,7 @@ def transpile_to_IQM(  # pylint: disable=too-many-arguments
         optimize_single_qubits: Whether to optimize single qubit gates away.
         ignore_barriers: Whether to ignore barriers when optimizing single qubit gates away.
         remove_final_rzs: Whether to remove the final z rotations. It is recommended always to set this to true as
-        the final RZ gates do no change the measurement outcomes of the circuit.
+            the final RZ gates do no change the measurement outcomes of the circuit.
         existing_moves_handling: How to handle existing MOVE gates in the circuit, required if the circuit contains
             MOVE gates.
         restrict_to_qubits: Restrict the transpilation to only use these specific physical qubits. Note that you will

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -336,7 +336,7 @@ class IQMProvider:
         """
         client = IQMClient(self.url, client_signature=f'qiskit-iqm {__version__}', **self.user_auth_args)
 
-        if name.startswith('facade_'):
+        if name and name.startswith('facade_'):
             if name == 'facade_adonis':
                 return IQMFacadeBackend(client)
 

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -339,9 +339,7 @@ class IQMProvider:
         if name.startswith('facade_'):
             if name == 'facade_adonis':
                 return IQMFacadeBackend(client)
-            else:
-                warnings.warn(
-                    f'Unknown facade backend: {name}. A regular backend associated with {self.url} will be used.'
-                )
+
+            warnings.warn(f'Unknown facade backend: {name}. A regular backend associated with {self.url} will be used.')
 
         return IQMBackend(client, calibration_set_id=calibration_set_id)

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -335,6 +335,13 @@ class IQMProvider:
                 If None, the server default calibration set will be used.
         """
         client = IQMClient(self.url, client_signature=f'qiskit-iqm {__version__}', **self.user_auth_args)
-        if name == 'facade_adonis':
-            return IQMFacadeBackend(client)
+
+        if name.startswith('facade_'):
+            if name == 'facade_adonis':
+                return IQMFacadeBackend(client)
+            else: 
+                warnings.warn(
+                    f'Unknown facade backend: {name}. A regular backend associated with {self.url} will be used.'
+                )
+                
         return IQMBackend(client, calibration_set_id=calibration_set_id)

--- a/src/iqm/qiskit_iqm/iqm_provider.py
+++ b/src/iqm/qiskit_iqm/iqm_provider.py
@@ -339,9 +339,9 @@ class IQMProvider:
         if name.startswith('facade_'):
             if name == 'facade_adonis':
                 return IQMFacadeBackend(client)
-            else: 
+            else:
                 warnings.warn(
                     f'Unknown facade backend: {name}. A regular backend associated with {self.url} will be used.'
                 )
-                
+
         return IQMBackend(client, calibration_set_id=calibration_set_id)


### PR DESCRIPTION
This PR introduces a warning in case a facade backend name is used that does not exist, I did not add a release note, it can be released with whatever else comes next