### PR TITLE
Handle unknown job statuses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 17.5
+============
+
+* Provider tolerates unrecognized job statuses from the server to ensure forward compatibility.
+  `#155 <https://github.com/iqm-finland/qiskit-on-iqm/pull/155>`_
+
 Version 17.4
 ============
 


### PR DESCRIPTION
We will have other job statuses in the future, and the client code should tolerate them even if it does not strictly need them.
This is mostly for situations where the server is updated but the client version is not.
