### PR TITLE
Fix unit tests compatibility with latest iqm-client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 17.6
+============
+
+* Fix unit tests compatibility with latest ``iqm-client``.
+  `#157 <https://github.com/iqm-finland/qiskit-on-iqm/pull/157>`_
+
 Version 17.5
 ============
 

--- a/tests/test_iqm_backend.py
+++ b/tests/test_iqm_backend.py
@@ -112,7 +112,7 @@ def test_set_max_circuits(backend):
 
 def test_serialize_circuit_raises_error_for_non_transpiled_circuit(circuit, linear_3q_architecture):
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
     client = IQMClient(url='http://some_url')
     client._token_manager = None  # Do not use authentication

--- a/tests/test_iqm_provider.py
+++ b/tests/test_iqm_provider.py
@@ -46,7 +46,7 @@ def test_get_backend(linear_3q_architecture):
     url = 'http://some_url'
     when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(linear_3q_architecture)
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
 
     provider = IQMProvider(url)
@@ -63,11 +63,11 @@ def test_client_signature(adonis_architecture):
     url = 'http://some_url'
     provider = IQMProvider(url)
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
     when(requests).get(
         'http://some_url/api/v1/calibration/default/gates', headers=matchers.ANY, timeout=matchers.ANY
-    ).thenReturn(get_mock_ok_response(adonis_architecture.model_dump()))
+    ).thenReturn(get_mock_ok_response(adonis_architecture.model_dump(mode='json')))
     backend = provider.get_backend()
     version_string = version('qiskit-iqm')
     assert f'qiskit-iqm {version_string}' in backend.client._signature
@@ -77,7 +77,7 @@ def test_get_facade_backend(adonis_architecture):
     url = 'http://some_url'
     when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
 
     provider = IQMProvider(url)
@@ -94,7 +94,7 @@ def test_get_facade_backend_raises_error_non_matching_architecture(linear_3q_arc
 
     when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(linear_3q_architecture)
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
 
     provider = IQMProvider(url)
@@ -125,9 +125,9 @@ def test_facade_backend_raises_error_on_remote_execution_fail(adonis_architectur
     when(IQMClient).create_run_request(...).thenReturn(run_request)
     when(IQMClient).submit_run_request(...).thenReturn(uuid.uuid4())
     when(IQMClient).get_run(ANY(uuid.UUID)).thenReturn(RunResult.from_dict(result))
-    when(IQMClient).get_run_status(ANY(uuid.UUID)).thenReturn(RunStatus.from_dict(result_status))
+    when(IQMClient).get_run_status(ANY(uuid.UUID)).thenReturn(RunStatus.model_validate(result_status))
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
 
     provider = IQMProvider(url)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing and mocking utility functions.
 """
+from json import dumps
 from unittest.mock import Mock
 from uuid import UUID
 
@@ -30,7 +31,7 @@ from iqm.qiskit_iqm.iqm_provider import IQMBackend
 def get_mocked_backend(architecture: DynamicQuantumArchitecture) -> tuple[IQMBackend, IQMClient]:
     """Returns an IQM backend running on a mocked IQM client that returns the given architecture."""
     when(requests).get('http://some_url/info/client-libraries', headers=matchers.ANY, timeout=matchers.ANY).thenReturn(
-        get_mock_ok_response({'iqm-client': {'min': '0.0', 'max': '999.0'}})
+        get_mock_ok_response({'iqm-client': {'name': 'IQM Client', 'min': '0.0', 'max': '999.0'}})
     )
     client = IQMClient(url='http://some_url')
     when(client).get_dynamic_quantum_architecture(None).thenReturn(architecture)
@@ -68,6 +69,7 @@ def get_mock_ok_response(json: dict) -> Response:
     mock_response.status_code = 200
     mock_response.history = []
     mock_response.json.return_value = json
+    mock_response.text = dumps(json)
     return mock_response
 
 


### PR DESCRIPTION
* Fix error in `test_facade_backend_raises_error_on_remote_execution_fail`
* Fix `"Could not verify IQM Client compatibility with the server"` warnings in unit tests.