### PR TITLE
Restrict iqm-client version to <22.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 18.2
+============
+
+* Restrict ``iqm-client`` version to ``<22.10``. `#161 <https://github.com/iqm-finland/qiskit-on-iqm/pull/161>`_
+
 Version 18.1
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "qiskit >= 1.0, < 1.3",
     "qiskit-aer >= 0.13.1, < 0.16",
-    "iqm-client >= 22.9, < 23.0"
+    "iqm-client >= 22.9, < 22.10"
 ]
 
 [project.urls]


### PR DESCRIPTION
Otherwise user would get `iqm.qiskit_iqm` from `iqm-client` and not see the deprecation error message for the `iqm.qiskit_iqm` from `qiskit-iqm`.